### PR TITLE
add Version to file tag(complete)

### DIFF
--- a/qo_utils/downloader.py
+++ b/qo_utils/downloader.py
@@ -31,7 +31,7 @@ def mkDir(dirn):
 
 
 def getDesc(u, mt):
-    return "{} [{}/{}]".format(mt["title"], u["bit_depth"], u["sampling_rate"])
+    return "{}{} [{}/{}]".format(mt["title"],' (' + mt["version"] + ')' if mt["version"] is not None else '', u["bit_depth"], u["sampling_rate"])
 
 
 def getCover(i, dirn):
@@ -57,13 +57,15 @@ def iterateIDs(client, id, path, quality, album=False):
 
     if album:
         meta = client.get_album_meta(id)
-        print("\nDownloading: {}\n".format(meta["title"]))
+
+        print("\nDownloading: {0} {1}\n".format(meta["title"], '(' + meta["version"] + ')' if meta["version"] is not None else ' '))
         dirT = (
             meta["artist"]["name"],
             meta["title"],
+            ' ' + meta["version"] if meta["version"] is not None else '',
             meta["release_date_original"].split("-")[0],
         )
-        sanitized_title = sanitize_filename("{} - {} [{}]".format(*dirT))
+        sanitized_title = sanitize_filename("{} - {}{} [{}]".format(*dirT)) #aa-{}
         dirn = path + sanitized_title
         mkDir(dirn)
         getCover(meta["image"]["large"], dirn)
@@ -86,13 +88,14 @@ def iterateIDs(client, id, path, quality, album=False):
 
         if "sample" not in parse:
             meta = client.get_track_meta(id)
-            print("\nDownloading: {}\n".format(meta["title"]))
+            print("\nDownloading: {0} {1}\n".format(meta["title"], '(' + meta["version"] + ')' if meta["version"] is not None else ' '))
             dirT = (
                 meta["album"]["artist"]["name"],
-                meta["title"],
+                meta["album"]["title"],
+                ' ' + meta["album"]["version"] if meta["album"]["version"] is not None else '',
                 meta["album"]["release_date_original"].split("-")[0],
             )
-            sanitized_title = sanitize_filename("{} - {} [{}]".format(*dirT))
+            sanitized_title = sanitize_filename("{} - {}{} [{}]".format(*dirT))
             dirn = path + sanitized_title
             mkDir(dirn)
             getCover(meta["album"]["image"]["large"], dirn)

--- a/qo_utils/metadata.py
+++ b/qo_utils/metadata.py
@@ -4,11 +4,25 @@ from mutagen.flac import FLAC
 from mutagen.mp3 import EasyMP3
 from pathvalidate import sanitize_filename
 
-
 def tag_flac(file, path, d, album, istrack=True):
     audio = FLAC(file)
+    try:
+        d["version"]
+    except KeyError:
+        audio["TITLE"] = d["title"]
+        dversion_exist = 0
+    else:
+        if d["version"] is None:
+            audio["TITLE"] = d["title"]# TRACK TITLE
+            dversion_exist = 0
+        else:
+            audio["TITLE"] = d["title"] + ' ' + '(' + d["version"] + ')'
+            dversion_exist = 1
+#   if d["version"] is None:
+#        audio["TITLE"] = d["title"]# TRACK TITLE
+#    else:
+#        audio["TITLE"] = d["title"] + ' ' + '(' + d["version"] + ')'
 
-    audio["TITLE"] = d["title"]  # TRACK TITLE
     audio["TRACKNUMBER"] = str(d["track_number"])  # TRACK NUMBER
     try:
         audio["COMPOSER"] = d["composer"]["name"]  # COMPOSER
@@ -24,30 +38,58 @@ def tag_flac(file, path, d, album, istrack=True):
             audio["ARTIST"] = album["artist"]["name"]
 
     if istrack:
-        audio["GENRE"] = ", ".join(d["album"]["genres_list"])  # GENRE
-        audio["ALBUMARTIST"] = d["album"]["artist"]["name"]  # ALBUM ARTIST
-        audio["TRACKTOTAL"] = str(d["album"]["tracks_count"])  # TRACK TOTAL
-        audio["ALBUM"] = d["album"]["title"]  # ALBUM TITLE
-        audio["YEAR"] = d["album"]["release_date_original"].split("-")[0]
+        if dversion_exist == 0:
+            audio["GENRE"] = ", ".join(d["album"]["genres_list"])  # GENRE
+            audio["ALBUMARTIST"] = d["album"]["artist"]["name"]  # ALBUM ARTIST
+            audio["TRACKTOTAL"] = str(d["album"]["tracks_count"])  # TRACK TOTAL
+            audio["ALBUM"] = d["album"]["title"] # ALBUM TITLE
+            audio["YEAR"] = d["album"]["release_date_original"].split("-")[0]
+        else:
+            audio["GENRE"] = ", ".join(d["album"]["genres_list"])  # GENRE
+            audio["ALBUMARTIST"] = d["album"]["artist"]["name"]  # ALBUM ARTIST
+            audio["TRACKTOTAL"] = str(d["album"]["tracks_count"])  # TRACK TOTAL
+            audio["ALBUM"] = d["album"]["title"] + ' ' + '(' + d["album"]["version"] + ')'  # ALBUM TITLE
+            audio["YEAR"] = d["album"]["release_date_original"].split("-")[0]
     else:
-        audio["GENRE"] = ", ".join(album["genres_list"])  # GENRE
-        audio["ALBUMARTIST"] = album["artist"]["name"]  # ALBUM ARTIST
-        audio["TRACKTOTAL"] = str(album["tracks_count"])  # TRACK TOTAL
-        audio["ALBUM"] = album["title"]  # ALBUM TITLE
-        audio["YEAR"] = album["release_date_original"].split("-")[0]  # YEAR
+        if dversion_exist == 0:
+            audio["GENRE"] = ", ".join(album["genres_list"])  # GENRE
+            audio["ALBUMARTIST"] = album["artist"]["name"]  # ALBUM ARTIST
+            audio["TRACKTOTAL"] = str(album["tracks_count"])  # TRACK TOTAL
+            audio["ALBUM"] = album["title"]  # ALBUM TITLE
+            audio["YEAR"] = album["release_date_original"].split("-")[0]  # YEAR
+        else:
+            audio["GENRE"] = ", ".join(album["genres_list"])  # GENRE
+            audio["ALBUMARTIST"] = album["artist"]["name"]  # ALBUM ARTIST
+            audio["TRACKTOTAL"] = str(album["tracks_count"])  # TRACK TOTAL
+            audio["ALBUM"] = album["title"] + ' ' + '(' + album["version"] + ')'  # ALBUM TITLE
+            audio["YEAR"] = album["release_date_original"].split("-")[0]  # YEAR
 
     audio.save()
-    title = sanitize_filename(d["title"])
+    if  dversion_exist == 1:
+        title = sanitize_filename(d["title"] + ' ' + '(' + d["version"] + ')')
+    else:
+        title = sanitize_filename(d["title"])
     try:
         os.rename(file, "{}/{:02}. {}.flac".format(path, d["track_number"], title))
     except FileExistsError:
         print("File already exists. Skipping...")
 
 
-def tag_mp3(file, path, d, album, istrack=True):
+def tag_mp3(file, path, d, album, istrack=True): #needs to be fixed
     audio = EasyMP3(file)
+    try:
+         d["version"]
+    except KeyError:
+        audio["TITLE"] = d["title"]
+        dversion_exist = 0
+    else:
+        if d["version"] is None:
+            audio["TITLE"] = d["title"]# TRACK TITLE
+            dversion_exist = 0
+        else:
+            audio["TITLE"] = d["title"] + ' ' + '(' + d["version"] + ')'
+            dversion_exist = 1
 
-    audio["title"] = d["title"]
     audio["tracknumber"] = str(d["track_number"])
     try:
         audio["composer"] = d["composer"]["name"]
@@ -60,20 +102,39 @@ def tag_mp3(file, path, d, album, istrack=True):
             audio["artist"] = d["album"]["artist"]["name"]  # TRACK ARTIST
         else:
             audio["artist"] = album["artist"]["name"]
-
     if istrack:
-        audio["genre"] = ", ".join(d["album"]["genres_list"])  # GENRE
-        audio["albumartist"] = d["album"]["artist"]["name"]  # ALBUM ARTIST
-        audio["album"] = d["album"]["title"]  # ALBUM TITLE
-        audio["date"] = d["album"]["release_date_original"].split("-")[0]
+        if dversion_exist == 1:
+            audio["genre"] = ", ".join(d["album"]["genres_list"])  # GENRE
+            audio["albumartist"] = d["album"]["artist"]["name"]  # ALBUM ARTIST
+            audio["album"] = d["album"]["title"] + ' ' + '(' + d["album"]["version"] + ')'  # ALBUM TITLE
+            audio["date"] = d["album"]["release_date_original"].split("-")[0]
+        else:
+            audio["genre"] = ", ".join(d["album"]["genres_list"])  # GENRE
+            audio["albumartist"] = d["album"]["artist"]["name"]  # ALBUM ARTIST
+            audio["album"] = d["album"]["title"]  # ALBUM TITLE
+            audio["date"] = d["album"]["release_date_original"].split("-")[0]
     else:
-        audio["GENRE"] = ", ".join(album["genres_list"])  # GENRE
-        audio["albumartist"] = album["artist"]["name"]  # ALBUM ARTIST
-        audio["album"] = album["title"]  # ALBUM TITLE
-        audio["date"] = album["release_date_original"].split("-")[0]  # YEAR
+        if album["version"] is not None:
+            audio["GENRE"] = ", ".join(album["genres_list"])  # GENRE
+            audio["albumartist"] = album["artist"]["name"]  # ALBUM ARTIST
+            try:
+                album["version"]
+            except KeyError:
+                audio["album"] = album["title"]
+            else:
+                audio["album"] = album["title"] + ' ' + '(' + album["version"] + ')'  # ALBUM TITLE
+            audio["date"] = album["release_date_original"].split("-")[0]  # YEAR
+        else:
+            audio["GENRE"] = ", ".join(album["genres_list"])  # GENRE
+            audio["albumartist"] = album["artist"]["name"]  # ALBUM ARTIST
+            audio["album"] = album["title"]  # ALBUM TITLE
+            audio["date"] = album["release_date_original"].split("-")[0]  # YEAR
 
     audio.save()
-    title = sanitize_filename(d["title"])
+    if dversion_exist == 1:
+        title = sanitize_filename(d["title"] + ' ' + '(' + d["version"] + ')')
+    else:
+        title = sanitize_filename(d["title"])
     try:
         os.rename(file, "{}/{:02}. {}.mp3".format(path, d["track_number"], title))
     except FileExistsError:


### PR DESCRIPTION
Hello.
When using program, I found that some part of music and album names are missing.
For example,
Album: Waiting for Love (Remixes) -> Waiting for love
Title: Waiting for love (~~~ Remix) -> Waiting for love.
Fixed this bug by adding Version Attribute provided by Qobuz.
Ex. Waiting for love (Autograf Remix)
Info provided by Qobuz (extracted by adding print(d) in tag_flac in metadata.py)

{
'maximum_bit_depth': 16,
'copyright': '℗ 2015 Avicii Music AB',
'performers': 'Avicii, MainArtist - Tim Bergling, Producer, ComposerLyricist - Vincent Pontare, Producer, ComposerLyricist - Simon Aldred, Vocals, AssociatedPerformer, ComposerLyricist - Salem Al Fakir, Producer, ComposerLyricist - Martin Garrix, Producer, Co-Producer, ComposerLyricist - Autograf, Producer, Additional Producer, Remixer, StudioPersonnel',
'audio_info': {
'replaygain_track_peak': 0.999969,
'replaygain_track_gain': -10.52
},
'performer': {
'name': 'Avicii',
'id': 369241
},
'article_ids': {
'LLS': 62217448,
'SMR': 62217449
},
'work': None,
'composer': {
'name': 'Vincent Pontare',
'id': 216038
},
'isrc': 'CHB701400183',
'title': 'Waiting For Love',
'version': 'Autograf Remix',
'duration': 288,
'parental_warning': False,
'track_number': 5,
'maximum_channel_count': 2,
'id': 25698674,
'media_number': 1,
'maximum_sampling_rate': 44.1,
'purchasable': True,
'streamable': True,
'previewable': True,
'sampleable': True,
'downloadable': True,
'displayable': True,
'purchasable_at': 1604098800,
'streamable_at': 1604098800,
'hires': False,
'hires_streamable': False
}
Bug above can be fixed by using Version attribute, so its title should be "Waiting for love (Autograf Remix)", not Waiting for love.
Sorry for my poor English, and feel free to comment if there is any other problem.

Album and track used in example above:

https://play.qobuz.com/album/0060254748751
https://open.qobuz.com/track/25698674