### PR TITLE
Addresses issue #52: adds custom file/folder formatting

### DIFF
--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -55,6 +55,9 @@ def reset_config(config_file):
     spoofer = spoofbuz.Spoofer()
     config["DEFAULT"]["app_id"] = str(spoofer.getAppId())
     config["DEFAULT"]["secrets"] = ",".join(spoofer.getSecrets().values())
+    config["DEFAULT"]["folder_format"] = "{artist} - {album} ({year}) "
+    "[{bit_depth}B-{sampling_rate}kHz]"
+    config["DEFAULT"]["track_format"] = "{tracknumber}. {tracktitle}"
     with open(config_file, "w") as configfile:
         config.write(configfile)
     logging.info(
@@ -98,6 +101,8 @@ def main():
         no_cover = config.getboolean("DEFAULT", "no_cover")
         no_database = config.getboolean("DEFAULT", "no_database")
         app_id = config["DEFAULT"]["app_id"]
+        folder_format = config["DEFAULT"]["folder_format"]
+        track_format = config["DEFAULT"]["track_format"]
         secrets = [
             secret for secret in config["DEFAULT"]["secrets"].split(",") if secret
         ]
@@ -131,6 +136,10 @@ def main():
         cover_og_quality=arguments.og_cover or og_cover,
         no_cover=arguments.no_cover or no_cover,
         downloads_db=None if no_database or arguments.no_db else QOBUZ_DB,
+        folder_format=arguments.folder_format
+        if hasattr(arguments, "folder_format") else folder_format,
+        track_format=arguments.track_format
+        if hasattr(arguments, "track_format") else track_format,
     )
     qobuz.initialize_client(email, password, app_id, secrets)
 

--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -101,8 +101,20 @@ def main():
         no_cover = config.getboolean("DEFAULT", "no_cover")
         no_database = config.getboolean("DEFAULT", "no_database")
         app_id = config["DEFAULT"]["app_id"]
+
+        if ("folder_format" not in config["DEFAULT"]
+                or "track_format" not in config["DEFAULT"]):
+            logging.info(f'{YELLOW}Config file does not include format string,'
+                         ' updating...')
+            config["DEFAULT"]["folder_format"] = "{artist} - {album} ({year}) "
+            "[{bit_depth}B-{sampling_rate}kHz]"
+            config["DEFAULT"]["track_format"] = "{tracknumber}. {tracktitle}"
+            with open(CONFIG_FILE, 'w') as cf:
+                config.write(cf)
+
         folder_format = config["DEFAULT"]["folder_format"]
         track_format = config["DEFAULT"]["track_format"]
+
         secrets = [
             secret for secret in config["DEFAULT"]["secrets"].split(",") if secret
         ]
@@ -137,9 +149,9 @@ def main():
         no_cover=arguments.no_cover or no_cover,
         downloads_db=None if no_database or arguments.no_db else QOBUZ_DB,
         folder_format=arguments.folder_format
-        if hasattr(arguments, "folder_format") else folder_format,
+        if arguments.folder_format is not None else folder_format,
         track_format=arguments.track_format
-        if hasattr(arguments, "track_format") else track_format,
+        if arguments.track_format is not None else track_format,
     )
     qobuz.initialize_client(email, password, app_id, secrets)
 

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -108,7 +108,7 @@ def add_common_arg(custom_parser, default_folder, default_quality):
         metavar='PATTERN',
         help='pattern for formatting folder names, e.g '
         '"{artist} - {album} ({year})". available keys: artist, '
-        'album, year, sampling_rate, bit_rate, tracktitle. '
+        'albumartist, album, year, sampling_rate, bit_rate, tracktitle. '
         'cannot contain characters used by the system, which includes /:<>',
     )
     custom_parser.add_argument(

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -102,6 +102,21 @@ def add_common_arg(custom_parser, default_folder, default_quality):
     custom_parser.add_argument(
         "--no-db", action="store_true", help="don't call the database"
     )
+    custom_parser.add_argument(
+        "-ff",
+        "--folder-format",
+        metavar='PATTERN',
+        help='pattern for formatting folder names, e.g '
+        '"{artist} - {album} ({year})". available keys: artist, '
+        'album, year, sampling_rate, bit_rate, tracktitle. '
+        'cannot contain characters used by the system, which includes /:<>',
+    )
+    custom_parser.add_argument(
+        "-tf",
+        "--track-format",
+        metavar='PATTERN',
+        help='pattern for formatting track names. see `folder-format`.',
+    )
 
 
 def qobuz_dl_args(

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -65,6 +65,9 @@ class QobuzDL:
         cover_og_quality=False,
         no_cover=False,
         downloads_db=None,
+        folder_format='{artist} - {album} ({year}) [{bit_depth}B-'
+        '{sampling_rate}kHz]',
+        track_format='{tracknumber}. {tracktitle}',
     ):
         self.directory = self.create_dir(directory)
         self.quality = quality
@@ -78,6 +81,8 @@ class QobuzDL:
         self.cover_og_quality = cover_og_quality
         self.no_cover = no_cover
         self.downloads_db = create_db(downloads_db) if downloads_db else None
+        self.folder_format = folder_format
+        self.track_format = track_format
 
     def initialize_client(self, email, pwd, app_id, secrets):
         self.client = qopy.Client(email, pwd, app_id, secrets)
@@ -140,6 +145,8 @@ class QobuzDL:
                 self.quality_fallback,
                 self.cover_og_quality,
                 self.no_cover,
+                folder_format=self.folder_format,
+                track_format=self.track_format
             )
             handle_download_id(self.downloads_db, item_id, add_id=True)
         except (requests.exceptions.RequestException, NonStreamable) as e:

--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -50,7 +50,6 @@ def get_description(u: dict, track_title, multiple=None):
     return downloading_title
 
 
-
 def get_format(client, item_dict,
                quality, is_track_id=False,
                track_url_dict=None) -> Tuple[str, bool, int, int]:
@@ -264,7 +263,6 @@ def download_id_by_type(
                                                         file_format)
         sanitized_title = sanitize_filename(
             folder_format.format(**album_attr)
-
         )
         dirn = os.path.join(path, sanitized_title)
         os.makedirs(dirn, exist_ok=True)

--- a/qobuz_dl/metadata.py
+++ b/qobuz_dl/metadata.py
@@ -44,14 +44,6 @@ def tag_flac(filename, root_dir, final_name, d, album,
     :param bool istrack
     :param bool em_image: Embed cover art into file
     """
-    print('in tag_flac d:')
-    # print(json.dumps(d.keys(), indent=2))
-    # print(d.keys())
-    print('album:')
-    # print(album.keys())
-    # print(json.dumps(album.keys(), indent=2))
-    print(f'{filename=}')
-    print(f'{istrack=}')
     audio = FLAC(filename)
 
     audio["TITLE"] = get_title(d)
@@ -190,13 +182,10 @@ def tag_mp3(filename, root_dir, final_name, d, album,
     audio['TPOS'] = id3.TPOS(encoding=3,
                              text=str(d["media_number"]))
 
-    def lookup_and_set_tags(tag_name, value):
-        id3tag = id3_legend[tag_name]
-        audio[id3tag.__name__] = id3tag(encoding=3, text=value)
-
     # write metadata in `tags` to file
     for k, v in tags.items():
-        lookup_and_set_tags(k, v)
+        id3tag = id3_legend[k]
+        audio[id3tag.__name__] = id3tag(encoding=3, text=v)
 
     if em_image:
         emb_image = os.path.join(root_dir, "cover.jpg")


### PR DESCRIPTION
Fixes #52 

Notes:

- Changed the return values of `get_format` in `downloader.py` to a 4-tuple.
- config file is automatically updated if the `folder_format` and `track_format` keys don't exist
- the format strings use the same syntax as python format strings, i.e. '`{tracknumber}. {tracktitle}'`
- also added error handling for when the cover art size is too large