### PR TITLE
Switched to Black formatting, and a small change

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+extend-ignore = E203, E266, E501
+# line length is intentionally set to 80 here because black uses Bugbear
+# See https://github.com/psf/black/blob/master/docs/the_black_code_style.md#line-length for more details
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -102,14 +102,17 @@ def main():
         no_database = config.getboolean("DEFAULT", "no_database")
         app_id = config["DEFAULT"]["app_id"]
 
-        if ("folder_format" not in config["DEFAULT"]
-                or "track_format" not in config["DEFAULT"]):
-            logging.info(f'{YELLOW}Config file does not include format string,'
-                         ' updating...')
+        if (
+            "folder_format" not in config["DEFAULT"]
+            or "track_format" not in config["DEFAULT"]
+        ):
+            logging.info(
+                f"{YELLOW}Config file does not include format string," " updating..."
+            )
             config["DEFAULT"]["folder_format"] = "{artist} - {album} ({year}) "
             "[{bit_depth}B-{sampling_rate}kHz]"
             config["DEFAULT"]["track_format"] = "{tracknumber}. {tracktitle}"
-            with open(CONFIG_FILE, 'w') as cf:
+            with open(CONFIG_FILE, "w") as cf:
                 config.write(cf)
 
         folder_format = config["DEFAULT"]["folder_format"]
@@ -149,9 +152,11 @@ def main():
         no_cover=arguments.no_cover or no_cover,
         downloads_db=None if no_database or arguments.no_db else QOBUZ_DB,
         folder_format=arguments.folder_format
-        if arguments.folder_format is not None else folder_format,
+        if arguments.folder_format is not None
+        else folder_format,
         track_format=arguments.track_format
-        if arguments.track_format is not None else track_format,
+        if arguments.track_format is not None
+        else track_format,
     )
     qobuz.initialize_client(email, password, app_id, secrets)
 

--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -58,6 +58,7 @@ def reset_config(config_file):
     config["DEFAULT"]["folder_format"] = "{artist} - {album} ({year}) "
     "[{bit_depth}B-{sampling_rate}kHz]"
     config["DEFAULT"]["track_format"] = "{tracknumber}. {tracktitle}"
+    config["DEFAULT"]["smart_discography"] = "false"
     with open(config_file, "w") as configfile:
         config.write(configfile)
     logging.info(
@@ -105,16 +106,19 @@ def main():
         if (
             "folder_format" not in config["DEFAULT"]
             or "track_format" not in config["DEFAULT"]
+            or "smart_discography" not in config["DEFAULT"]
         ):
             logging.info(
-                f"{YELLOW}Config file does not include format string," " updating..."
+                f"{YELLOW}Config file does not include some settings, updating..."
             )
             config["DEFAULT"]["folder_format"] = "{artist} - {album} ({year}) "
             "[{bit_depth}B-{sampling_rate}kHz]"
             config["DEFAULT"]["track_format"] = "{tracknumber}. {tracktitle}"
+            config["DEFAULT"]["smart_discography"] = "false"
             with open(CONFIG_FILE, "w") as cf:
                 config.write(cf)
 
+        smart_discography = config.getboolean("DEFAULT", "smart_discography")
         folder_format = config["DEFAULT"]["folder_format"]
         track_format = config["DEFAULT"]["track_format"]
 
@@ -151,12 +155,9 @@ def main():
         cover_og_quality=arguments.og_cover or og_cover,
         no_cover=arguments.no_cover or no_cover,
         downloads_db=None if no_database or arguments.no_db else QOBUZ_DB,
-        folder_format=arguments.folder_format
-        if arguments.folder_format is not None
-        else folder_format,
-        track_format=arguments.track_format
-        if arguments.track_format is not None
-        else track_format,
+        folder_format=arguments.folder_format or folder_format,
+        track_format=arguments.track_format or track_format,
+        smart_discography=arguments.smart_discography or smart_discography,
     )
     qobuz.initialize_client(email, password, app_id, secrets)
 

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -105,17 +105,17 @@ def add_common_arg(custom_parser, default_folder, default_quality):
     custom_parser.add_argument(
         "-ff",
         "--folder-format",
-        metavar='PATTERN',
-        help='pattern for formatting folder names, e.g '
+        metavar="PATTERN",
+        help="pattern for formatting folder names, e.g "
         '"{artist} - {album} ({year})". available keys: artist, '
-        'albumartist, album, year, sampling_rate, bit_rate, tracktitle. '
-        'cannot contain characters used by the system, which includes /:<>',
+        "albumartist, album, year, sampling_rate, bit_rate, tracktitle. "
+        "cannot contain characters used by the system, which includes /:<>",
     )
     custom_parser.add_argument(
         "-tf",
         "--track-format",
-        metavar='PATTERN',
-        help='pattern for formatting track names. see `folder-format`.',
+        metavar="PATTERN",
+        help="pattern for formatting track names. see `folder-format`.",
     )
 
 

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -117,6 +117,12 @@ def add_common_arg(custom_parser, default_folder, default_quality):
         metavar="PATTERN",
         help="pattern for formatting track names. see `folder-format`.",
     )
+    custom_parser.add_argument(
+        "-sd",
+        "--smart-discography",
+        action="store_true",
+        help="Try to filter out unrelated albums when requesting an artists discography.",
+    )
 
 
 def qobuz_dl_args(

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -106,10 +106,10 @@ def add_common_arg(custom_parser, default_folder, default_quality):
         "-ff",
         "--folder-format",
         metavar="PATTERN",
-        help="pattern for formatting folder names, e.g "
-        '"{artist} - {album} ({year})". available keys: artist, '
-        "albumartist, album, year, sampling_rate, bit_rate, tracktitle. "
-        "cannot contain characters used by the system, which includes /:<>",
+        help="""pattern for formatting folder names, e.g
+        "{artist} - {album} ({year})". available keys: artist,
+        albumartist, album, year, sampling_rate, bit_rate, tracktitle, version.
+        cannot contain characters used by the system, which includes /:<>""",
     )
     custom_parser.add_argument(
         "-tf",
@@ -117,11 +117,15 @@ def add_common_arg(custom_parser, default_folder, default_quality):
         metavar="PATTERN",
         help="pattern for formatting track names. see `folder-format`.",
     )
+    # TODO: add customization options
     custom_parser.add_argument(
-        "-sd",
+        "-s",
         "--smart-discography",
         action="store_true",
-        help="Try to filter out unrelated albums when requesting an artists discography.",
+        help="""Try to filter out spam-like albums when requesting an artist's
+        discography, and other optimizations. Filters albums not made by requested
+        artist, and deluxe/live/collection albums. Gives preference to remastered
+        albums, high bit depth/dynamic range, and low sampling rates (to save space).""",
     )
 
 

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -99,7 +99,9 @@ class QobuzDL:
         os.makedirs(fix, exist_ok=True)
         return fix
 
-    def get_url_info(url: str) -> Tuple[str, str]:
+    def get_url_info(self, url: str) -> Tuple[str, str]:
+        '''Returns the type of the url and the id.
+        '''
         r = re.search(
             r"(?:https:\/\/(?:w{3}|open|play)\.qobuz\.com)?(?:\/[a-z]{2}-[a-z]{2})"
             r"?\/(album|artist|track|playlist|label)(?:\/[-\w\d]+)?\/([\w\d]+)",
@@ -152,7 +154,7 @@ class QobuzDL:
             "track": {"album": False, "func": None, "iterable_key": None},
         }
         try:
-            url_type, item_id = self.get_info(url)
+            url_type, item_id = self.get_url_info(url)
             type_dict = possibles[url_type]
         except (KeyError, IndexError):
             logger.info(

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -101,7 +101,14 @@ class QobuzDL:
 
     def get_url_info(self, url: str) -> Tuple[str, str]:
         '''Returns the type of the url and the id.
+
+        Compatible with urls of the form:
+            https://www.qobuz.com/us-en/{type}/{name}/{id}
+            https://open.qobuz.com/{type}/{id}
+            https://play.qobuz.com/{type}/{id}
+            /us-en/{type}/-/{id}
         '''
+
         r = re.search(
             r"(?:https:\/\/(?:w{3}|open|play)\.qobuz\.com)?(?:\/[a-z]{2}-[a-z]{2})"
             r"?\/(album|artist|track|playlist|label)(?:\/[-\w\d]+)?\/([\w\d]+)",

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -187,8 +187,8 @@ class QobuzDL:
             )
 
             if self.smart_discography and url_type == "artist":
-                logger.info(f"{YELLOW}Filtering {content_name}'s discography")
-                items = self.smart_discography_filter(
+                # change `save_space` and `skip_extras` for customization
+                items = self._smart_discography_filter(
                     content,
                     save_space=True,
                     skip_extras=True,
@@ -490,8 +490,8 @@ class QobuzDL:
             with open(os.path.join(pl_directory, pl_name), "w") as pl:
                 pl.write("\n\n".join(track_list))
 
-    def smart_discography_filter(
-        self, contents: list, save_space=False, skip_extras=False
+    def _smart_discography_filter(
+        self, contents: list, save_space: bool = False, skip_extras: bool = False
     ) -> list:
         """When downloading some artists' discography, many random and spam-like
         albums can get downloaded. This helps filter those out to just get the good stuff.
@@ -508,8 +508,8 @@ class QobuzDL:
         """
 
         # for debugging
-        def print_album(album: dict):
-            logger.info(
+        def print_album(album: dict) -> None:
+            logger.debug(
                 f"{album['title']} - {album.get('version', '~~')} ({album['maximum_bit_depth']}/{album['maximum_sampling_rate']} by {album['artist']['name']}) {album['id']}"
             )
 
@@ -519,6 +519,7 @@ class QobuzDL:
         }
 
         def is_type(album_t: str, album: dict) -> bool:
+            """Check if album is of type `album_t`"""
             version = album.get("version", "")
             title = album.get("title", "")
             regex = TYPE_REGEXES[album_t]
@@ -553,7 +554,7 @@ class QobuzDL:
             )
             remaster_exists = any(is_type("remaster", a) for a in albums)
 
-            def is_valid(album):
+            def is_valid(album: dict) -> bool:
                 return (
                     album["maximum_bit_depth"] == best_bit_depth
                     and album["maximum_sampling_rate"] == best_sampling_rate

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -21,8 +21,7 @@ WEB_URL = "https://play.qobuz.com/"
 ARTISTS_SELECTOR = "td.chartlist-artist > a"
 TITLE_SELECTOR = "td.chartlist-name > a"
 EXTENSIONS = (".mp3", ".flac")
-QUALITIES = {5: "5 - MP3", 6: "6 - FLAC",
-             7: "7 - 24B<96kHz", 27: "27 - 24B>96kHz"}
+QUALITIES = {5: "5 - MP3", 6: "6 - FLAC", 7: "7 - 24B<96kHz", 27: "27 - 24B>96kHz"}
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +32,7 @@ class PartialFormatter(string.Formatter):
 
     def get_field(self, field_name, args, kwargs):
         try:
-            val = super(PartialFormatter, self).get_field(field_name,
-                                                          args, kwargs)
+            val = super(PartialFormatter, self).get_field(field_name, args, kwargs)
         except (KeyError, AttributeError):
             val = None, field_name
         return val
@@ -65,9 +63,9 @@ class QobuzDL:
         cover_og_quality=False,
         no_cover=False,
         downloads_db=None,
-        folder_format='{artist} - {album} ({year}) [{bit_depth}B-'
-        '{sampling_rate}kHz]',
-        track_format='{tracknumber}. {tracktitle}',
+        folder_format="{artist} - {album} ({year}) [{bit_depth}B-"
+        "{sampling_rate}kHz]",
+        track_format="{tracknumber}. {tracktitle}",
     ):
         self.directory = self.create_dir(directory)
         self.quality = quality
@@ -109,20 +107,19 @@ class QobuzDL:
         ).group(1)
 
     def get_type(self, url):
-        if re.match(r'https?', url) is not None:
-            url_type = url.split('/')[3]
-            if url_type not in ['album', 'artist', 'playlist',
-                                'track', 'label']:
+        if re.match(r"https?", url) is not None:
+            url_type = url.split("/")[3]
+            if url_type not in ["album", "artist", "playlist", "track", "label"]:
                 if url_type == "user":
-                    url_type = url.split('/')[-1]
+                    url_type = url.split("/")[-1]
                 else:
                     # url is from Qobuz store
                     # e.g. "https://www.qobuz.com/us-en/album/..."
-                    url_type = url.split('/')[4]
+                    url_type = url.split("/")[4]
         else:
             # url missing base
             # e.g. "/us-en/album/{artist}/{id}"
-            url_type = url.split('/')[2]
+            url_type = url.split("/")[2]
         return url_type
 
     def download_from_id(self, item_id, album=True, alt_path=None):
@@ -146,7 +143,7 @@ class QobuzDL:
                 self.cover_og_quality,
                 self.no_cover,
                 folder_format=self.folder_format,
-                track_format=self.track_format
+                track_format=self.track_format,
             )
             handle_download_id(self.downloads_db, item_id, add_id=True)
         except (requests.exceptions.RequestException, NonStreamable) as e:
@@ -175,8 +172,7 @@ class QobuzDL:
             item_id = self.get_id(url)
         except (KeyError, IndexError):
             logger.info(
-                f'{RED}Invalid url: "{url}". Use urls from '
-                'https://play.qobuz.com!'
+                f'{RED}Invalid url: "{url}". Use urls from ' "https://play.qobuz.com!"
             )
             return
         if type_dict["func"]:
@@ -189,8 +185,7 @@ class QobuzDL:
             new_path = self.create_dir(
                 os.path.join(self.directory, sanitize_filename(content_name))
             )
-            items = [item[type_dict["iterable_key"]]["items"]
-                     for item in content][0]
+            items = [item[type_dict["iterable_key"]]["items"] for item in content][0]
             logger.info(f"{YELLOW}{len(items)} downloads in queue")
             for item in items:
                 self.download_from_id(
@@ -242,8 +237,7 @@ class QobuzDL:
             f"{YELLOW}qobuz-dl will attempt to download the first "
             f"{self.lucky_limit} results."
         )
-        results = self.search_by_type(query, self.lucky_type,
-                                      self.lucky_limit, True)
+        results = self.search_by_type(query, self.lucky_type, self.lucky_limit, True)
 
         if download:
             self.download_list_of_urls(results)
@@ -306,8 +300,7 @@ class QobuzDL:
                     )
 
                 url = "{}{}/{}".format(WEB_URL, item_type, i.get("id", ""))
-                item_list.append({"text": text, "url": url} if not lucky
-                                 else url)
+                item_list.append({"text": text, "url": url} if not lucky else url)
             return item_list
         except (KeyError, IndexError):
             logger.info(f"{RED}Invalid type: {item_type}")
@@ -319,7 +312,7 @@ class QobuzDL:
         except (ImportError, ModuleNotFoundError):
             if os.name == "nt":
                 sys.exit(
-                    'Please install curses with '
+                    "Please install curses with "
                     '"pip3 install windows-curses" to continue'
                 )
             raise
@@ -339,15 +332,15 @@ class QobuzDL:
 
         try:
             item_types = ["Albums", "Tracks", "Artists", "Playlists"]
-            selected_type = pick(item_types,
-                                 "I'll search for:\n[press Intro]"
-                                 )[0][:-1].lower()
-            logger.info(f"{YELLOW}Ok, we'll search for "
-                        f"{selected_type}s{RESET}")
+            selected_type = pick(item_types, "I'll search for:\n[press Intro]")[0][
+                :-1
+            ].lower()
+            logger.info(f"{YELLOW}Ok, we'll search for " f"{selected_type}s{RESET}")
             final_url_list = []
             while True:
-                query = input(f"{CYAN}Enter your search: [Ctrl + c to quit]\n"
-                              f"-{DF} ")
+                query = input(
+                    f"{CYAN}Enter your search: [Ctrl + c to quit]\n" f"-{DF} "
+                )
                 logger.info(f"{YELLOW}Searching...{RESET}")
                 options = self.search_by_type(
                     query, selected_type, self.interactive_limit
@@ -369,8 +362,7 @@ class QobuzDL:
                     options_map_func=get_title_text,
                 )
                 if len(selected_items) > 0:
-                    [final_url_list.append(i[0]["url"])
-                     for i in selected_items]
+                    [final_url_list.append(i[0]["url"]) for i in selected_items]
                     y_n = pick(
                         ["Yes", "No"],
                         "Items were added to queue to be downloaded. "
@@ -427,13 +419,11 @@ class QobuzDL:
         pl_title = sanitize_filename(soup.select_one("h1").text)
         pl_directory = os.path.join(self.directory, pl_title)
         logger.info(
-            f"{YELLOW}Downloading playlist: {pl_title} "
-            f"({len(track_list)} tracks)"
+            f"{YELLOW}Downloading playlist: {pl_title} " f"({len(track_list)} tracks)"
         )
 
         for i in track_list:
-            track_id = self.get_id(self.search_by_type(i, "track", 1,
-                                                       lucky=True)[0])
+            track_id = self.get_id(self.search_by_type(i, "track", 1, lucky=True)[0])
             if track_id:
                 self.download_from_id(track_id, False, pl_directory)
 
@@ -465,8 +455,7 @@ class QobuzDL:
             if not audio_files or len(audio_files) != len(audio_rel_files):
                 continue
 
-            for audio_rel_file, audio_file in zip(audio_rel_files,
-                                                  audio_files):
+            for audio_rel_file, audio_file in zip(audio_rel_files, audio_files):
                 try:
                     pl_item = (
                         EasyMP3(audio_file)

--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -247,7 +247,7 @@ def download_id_by_type(
             return
 
         logger.info(
-            f"\n{YELLOW}Downloading: {album_title}\n" f"Quality: {file_format}\n"
+            f"\n{YELLOW}Downloading: {album_title}\nQuality: {file_format} ({bit_depth}/{sampling_rate})\n"
         )
         album_attr = {
             "artist": meta["artist"]["name"],

--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -367,10 +367,8 @@ def _clean_format_str(folder: str, track: str, file_format: str) -> Tuple[str, s
         fs = fs.strip()
 
         # default to pre-chosen string if format is invalid
-        if (
-            file_format in ("MP3", "Unknown")
-            and "bit_depth" in file_format
-            or "sampling_rate" in file_format
+        if file_format in ("MP3", "Unknown") and (
+            "bit_depth" in fs or "sampling_rate" in fs
         ):
             default = DEFAULT_FORMATS[file_format][i]
             logger.error(

--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -13,14 +13,14 @@ from qobuz_dl.exceptions import NonStreamable
 QL_DOWNGRADE = "FormatRestrictedByFormatAvailability"
 # used in case of error
 DEFAULT_FORMATS = {
-    'MP3': [
-        '{artist} - {album} ({year}) [MP3]',
-        '{tracknumber}. {tracktitle}',
+    "MP3": [
+        "{artist} - {album} ({year}) [MP3]",
+        "{tracknumber}. {tracktitle}",
     ],
-    'Unknown': [
-        '{artist} - {album}',
-        '{tracknumber}. {tracktitle}',
-    ]
+    "Unknown": [
+        "{artist} - {album}",
+        "{tracknumber}. {tracktitle}",
+    ],
 }
 
 logger = logging.getLogger(__name__)
@@ -43,16 +43,16 @@ def tqdm_download(url, fname, track_name):
 
 
 def get_description(u: dict, track_title, multiple=None):
-    downloading_title = f'{track_title} '
+    downloading_title = f"{track_title} "
     f'[{u["bit_depth"]}/{u["sampling_rate"]}]'
     if multiple:
         downloading_title = f"[Disc {multiple}] {downloading_title}"
     return downloading_title
 
 
-def get_format(client, item_dict,
-               quality, is_track_id=False,
-               track_url_dict=None) -> Tuple[str, bool, int, int]:
+def get_format(
+    client, item_dict, quality, is_track_id=False, track_url_dict=None
+) -> Tuple[str, bool, int, int]:
     quality_met = True
     if int(quality) == 5:
         return ("MP3", quality_met, None, None)
@@ -69,8 +69,7 @@ def get_format(client, item_dict,
         restrictions = new_track_dict.get("restrictions")
         if isinstance(restrictions, list):
             if any(
-                restriction.get("code") == QL_DOWNGRADE
-                for restriction in restrictions
+                restriction.get("code") == QL_DOWNGRADE for restriction in restrictions
             ):
                 quality_met = False
 
@@ -119,7 +118,7 @@ def download_and_tag(
     is_mp3,
     embed_art=False,
     multiple=None,
-    track_format='{tracknumber}. {tracktitle}',
+    track_format="{tracknumber}. {tracktitle}",
 ):
     """
     Download and tag a file
@@ -155,14 +154,15 @@ def download_and_tag(
     track_title = track_metadata.get("title")
     artist = _safe_get(track_metadata, "performer", "name")
     filename_attr = {
-        'artist': artist,
-        'albumartist': _safe_get(track_metadata, "album", "artist", "name",
-                                 default=artist),
-        'bit_depth': track_metadata['maximum_bit_depth'],
-        'sampling_rate': track_metadata['maximum_sampling_rate'],
-        'tracktitle': track_title,
-        'version': track_metadata.get("version"),
-        'tracknumber': f"{track_metadata['track_number']:02}"
+        "artist": artist,
+        "albumartist": _safe_get(
+            track_metadata, "album", "artist", "name", default=artist
+        ),
+        "bit_depth": track_metadata["maximum_bit_depth"],
+        "sampling_rate": track_metadata["maximum_sampling_rate"],
+        "tracktitle": track_title,
+        "version": track_metadata.get("version"),
+        "tracknumber": f"{track_metadata['track_number']:02}",
     }
     # track_format is a format string
     # e.g. '{tracknumber}. {artist} - {tracktitle}'
@@ -201,9 +201,8 @@ def download_id_by_type(
     downgrade_quality=True,
     cover_og_quality=False,
     no_cover=False,
-    folder_format='{artist} - {album} ({year}) '
-    '[{bit_depth}B-{sampling_rate}kHz]',
-    track_format='{tracknumber}. {tracktitle}',
+    folder_format="{artist} - {album} ({year}) " "[{bit_depth}B-{sampling_rate}kHz]",
+    track_format="{tracknumber}. {tracktitle}",
 ):
     """
     Download and get metadata by ID and type (album or track)
@@ -243,43 +242,39 @@ def download_id_by_type(
 
         if not downgrade_quality and not quality_met:
             logger.info(
-                f"{OFF}Skipping {album_title} as it doesn't "
-                "meet quality requirement"
+                f"{OFF}Skipping {album_title} as it doesn't " "meet quality requirement"
             )
             return
 
-        logger.info(f"\n{YELLOW}Downloading: {album_title}\n"
-                    f"Quality: {file_format}\n")
-        album_attr = {
-            'artist': meta["artist"]["name"],
-            'album': album_title,
-            'year': meta["release_date_original"].split("-")[0],
-            'format': file_format,
-            'bit_depth': bit_depth,
-            'sampling_rate': sampling_rate
-        }
-        folder_format, track_format = _clean_format_str(folder_format,
-                                                        track_format,
-                                                        file_format)
-        sanitized_title = sanitize_filename(
-            folder_format.format(**album_attr)
+        logger.info(
+            f"\n{YELLOW}Downloading: {album_title}\n" f"Quality: {file_format}\n"
         )
+        album_attr = {
+            "artist": meta["artist"]["name"],
+            "album": album_title,
+            "year": meta["release_date_original"].split("-")[0],
+            "format": file_format,
+            "bit_depth": bit_depth,
+            "sampling_rate": sampling_rate,
+        }
+        folder_format, track_format = _clean_format_str(
+            folder_format, track_format, file_format
+        )
+        sanitized_title = sanitize_filename(folder_format.format(**album_attr))
         dirn = os.path.join(path, sanitized_title)
         os.makedirs(dirn, exist_ok=True)
 
         if no_cover:
             logger.info(f"{OFF}Skipping cover")
         else:
-            get_extra(meta["image"]["large"], dirn,
-                      og_quality=cover_og_quality)
+            get_extra(meta["image"]["large"], dirn, og_quality=cover_og_quality)
 
         if "goodies" in meta:
             try:
                 get_extra(meta["goodies"][0]["url"], dirn, "booklet.pdf")
             except:  # noqa
                 pass
-        media_numbers = [track["media_number"] for track in
-                         meta["tracks"]["items"]]
+        media_numbers = [track["media_number"] for track in meta["tracks"]["items"]]
         is_multiple = True if len([*{*media_numbers}]) > 1 else False
         for i in meta["tracks"]["items"]:
             parse = client.get_track_url(i["id"], quality)
@@ -307,13 +302,14 @@ def download_id_by_type(
             meta = client.get_track_meta(item_id)
             track_title = get_title(meta)
             logger.info(f"\n{YELLOW}Downloading: {track_title}")
-            format_info = get_format(client, meta, quality,
-                                     is_track_id=True, track_url_dict=parse)
+            format_info = get_format(
+                client, meta, quality, is_track_id=True, track_url_dict=parse
+            )
             file_format, quality_met, bit_depth, sampling_rate = format_info
 
-            folder_format, track_format = _clean_format_str(folder_format,
-                                                            track_format,
-                                                            bit_depth)
+            folder_format, track_format = _clean_format_str(
+                folder_format, track_format, bit_depth
+            )
 
             if not downgrade_quality and not quality_met:
                 logger.info(
@@ -322,15 +318,13 @@ def download_id_by_type(
                 )
                 return
             track_attr = {
-                'artist': meta["album"]["artist"]["name"],
-                'tracktitle': track_title,
-                'year': meta["album"]["release_date_original"].split("-")[0],
-                'bit_depth': bit_depth,
-                'sampling_rate': sampling_rate
+                "artist": meta["album"]["artist"]["name"],
+                "tracktitle": track_title,
+                "year": meta["album"]["release_date_original"].split("-")[0],
+                "bit_depth": bit_depth,
+                "sampling_rate": sampling_rate,
             }
-            sanitized_title = sanitize_filename(
-                folder_format.format(**track_attr)
-            )
+            sanitized_title = sanitize_filename(folder_format.format(**track_attr))
 
             dirn = os.path.join(path, sanitized_title)
             os.makedirs(dirn, exist_ok=True)
@@ -338,13 +332,20 @@ def download_id_by_type(
                 logger.info(f"{OFF}Skipping cover")
             else:
                 get_extra(
-                    meta["album"]["image"]["large"], dirn,
-                    og_quality=cover_og_quality
+                    meta["album"]["image"]["large"], dirn, og_quality=cover_og_quality
                 )
             is_mp3 = True if int(quality) == 5 else False
-            download_and_tag(dirn, count, parse, meta,
-                             meta, True, is_mp3, embed_art,
-                             track_format=track_format)
+            download_and_tag(
+                dirn,
+                count,
+                parse,
+                meta,
+                meta,
+                True,
+                is_mp3,
+                embed_art,
+                track_format=track_format,
+            )
         else:
             logger.info(f"{OFF}Demo. Skipping")
     logger.info(f"{GREEN}Completed")
@@ -352,25 +353,30 @@ def download_id_by_type(
 
 # ----------- Utilities -----------
 
-def _clean_format_str(folder: str, track: str,
-                      file_format: str) -> Tuple[str, str]:
-    '''Cleans up the format strings, avoids errors
+
+def _clean_format_str(folder: str, track: str, file_format: str) -> Tuple[str, str]:
+    """Cleans up the format strings, avoids errors
     with MP3 files.
-    '''
+    """
     final = []
     for i, fs in enumerate((folder, track)):
-        if fs.endswith('.mp3'):
+        if fs.endswith(".mp3"):
             fs = fs[:-4]
-        elif fs.endswith('.flac'):
+        elif fs.endswith(".flac"):
             fs = fs[:-5]
         fs = fs.strip()
 
         # default to pre-chosen string if format is invalid
-        if (file_format in ('MP3', 'Unknown') and
-                'bit_depth' in file_format or 'sampling_rate' in file_format):
+        if (
+            file_format in ("MP3", "Unknown")
+            and "bit_depth" in file_format
+            or "sampling_rate" in file_format
+        ):
             default = DEFAULT_FORMATS[file_format][i]
-            logger.error(f'{RED}invalid format string for format {file_format}'
-                         f'. defaulting to {default}')
+            logger.error(
+                f"{RED}invalid format string for format {file_format}"
+                f". defaulting to {default}"
+            )
             fs = default
         final.append(fs)
 
@@ -378,18 +384,18 @@ def _clean_format_str(folder: str, track: str,
 
 
 def _safe_get(d: dict, *keys, default=None):
-    '''A replacement for chained `get()` statements on dicts:
+    """A replacement for chained `get()` statements on dicts:
     >>> d = {'foo': {'bar': 'baz'}}
     >>> _safe_get(d, 'baz')
     None
     >>> _safe_get(d, 'foo', 'bar')
     'baz'
-    '''
+    """
     curr = d
     res = default
     for key in keys:
         res = curr.get(key, default)
-        if res == default or not hasattr(res, '__getitem__'):
+        if res == default or not hasattr(res, "__getitem__"):
             return res
         else:
             curr = res

--- a/qobuz_dl/metadata.py
+++ b/qobuz_dl/metadata.py
@@ -1,3 +1,4 @@
+import re
 import os
 import logging
 
@@ -37,13 +38,12 @@ def _format_genres(genres: list) -> str:
     """Fixes the weirdly formatted genre lists returned by the API.
     >>> g = ['Pop/Rock', 'Pop/Rock→Rock', 'Pop/Rock→Rock→Alternatif et Indé']
     >>> _format_genres(g)
-    'Pop/Rock, Rock, Alternatif et Indé'
+    'Pop, Rock, Alternatif et Indé'
     """
-
-    if genres == []:
-        return ""
-    else:
-        return ", ".join(genres[-1].split("\u2192"))
+    genres = re.findall(r"([^\u2192\/]+)", "/".join(genres))
+    no_repeats = []
+    [no_repeats.append(g) for g in genres if g not in no_repeats]
+    return ", ".join(no_repeats)
 
 
 # Use KeyError catching instead of dict.get to avoid empty tags

--- a/qobuz_dl/metadata.py
+++ b/qobuz_dl/metadata.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 # unicode symbols
-COPYRIGHT, PHON_COPYRIGHT = '\u2117', '\u00a9'
+COPYRIGHT, PHON_COPYRIGHT = "\u2117", "\u00a9"
 # if a metadata block exceeds this, mutagen will raise error
 # and the file won't be tagged
 FLAC_MAX_BLOCKSIZE = 16777215
@@ -28,27 +28,26 @@ def get_title(track_dict):
 
 
 def _format_copyright(s: str) -> str:
-    s = s.replace('(P)', PHON_COPYRIGHT)
-    s = s.replace('(C)', COPYRIGHT)
+    s = s.replace("(P)", PHON_COPYRIGHT)
+    s = s.replace("(C)", COPYRIGHT)
     return s
 
 
 def _format_genres(genres: list) -> str:
-    '''Fixes the weirdly formatted genre lists returned by the API.
+    """Fixes the weirdly formatted genre lists returned by the API.
     >>> g = ['Pop/Rock', 'Pop/Rock→Rock', 'Pop/Rock→Rock→Alternatif et Indé']
     >>> _format_genres(g)
     'Pop/Rock, Rock, Alternatif et Indé'
-    '''
+    """
 
     if genres == []:
-        return ''
+        return ""
     else:
-        return ', '.join(genres[-1].split('\u2192'))
+        return ", ".join(genres[-1].split("\u2192"))
 
 
 # Use KeyError catching instead of dict.get to avoid empty tags
-def tag_flac(filename, root_dir, final_name, d, album,
-             istrack=True, em_image=False):
+def tag_flac(filename, root_dir, final_name, d, album, istrack=True, em_image=False):
     """
     Tag a FLAC file
 
@@ -116,8 +115,10 @@ def tag_flac(filename, root_dir, final_name, d, album,
             # rest of the metadata still gets embedded
             # when the image size is too big
             if os.path.getsize(cover_image) > FLAC_MAX_BLOCKSIZE:
-                raise Exception("downloaded cover size too large to embed. "
-                                "turn off `og_cover` to avoid error")
+                raise Exception(
+                    "downloaded cover size too large to embed. "
+                    "turn off `og_cover` to avoid error"
+                )
 
             image = Picture()
             image.type = 3
@@ -133,8 +134,7 @@ def tag_flac(filename, root_dir, final_name, d, album,
     os.rename(filename, final_name)
 
 
-def tag_mp3(filename, root_dir, final_name, d, album,
-            istrack=True, em_image=False):
+def tag_mp3(filename, root_dir, final_name, d, album, istrack=True, em_image=False):
     """
     Tag an mp3 file
 
@@ -159,7 +159,7 @@ def tag_mp3(filename, root_dir, final_name, d, album,
         "label": id3.TPUB,
         "performer": id3.TOPE,
         "title": id3.TIT2,
-        "year": id3.TYER
+        "year": id3.TYER,
     }
     try:
         audio = id3.ID3(filename)
@@ -168,19 +168,19 @@ def tag_mp3(filename, root_dir, final_name, d, album,
 
     # temporarily holds metadata
     tags = dict()
-    tags['title'] = get_title(d)
+    tags["title"] = get_title(d)
     try:
-        tags['label'] = album["label"]["name"]
+        tags["label"] = album["label"]["name"]
     except KeyError:
         pass
 
     try:
-        tags['artist'] = d["performer"]["name"]
+        tags["artist"] = d["performer"]["name"]
     except KeyError:
         if istrack:
-            tags['artist'] = d["album"]["artist"]["name"]
+            tags["artist"] = d["album"]["artist"]["name"]
         else:
-            tags['artist'] = album["artist"]["name"]
+            tags["artist"] = album["artist"]["name"]
 
     if istrack:
         tags["genre"] = _format_genres(d["album"]["genres_list"])
@@ -197,12 +197,10 @@ def tag_mp3(filename, root_dir, final_name, d, album,
         tags["copyright"] = _format_copyright(album["copyright"])
         tracktotal = str(album["tracks_count"])
 
-    tags['year'] = tags['date'][:4]
+    tags["year"] = tags["date"][:4]
 
-    audio['TRCK'] = id3.TRCK(encoding=3,
-                             text=f'{d["track_number"]}/{tracktotal}')
-    audio['TPOS'] = id3.TPOS(encoding=3,
-                             text=str(d["media_number"]))
+    audio["TRCK"] = id3.TRCK(encoding=3, text=f'{d["track_number"]}/{tracktotal}')
+    audio["TPOS"] = id3.TPOS(encoding=3, text=str(d["media_number"]))
 
     # write metadata in `tags` to file
     for k, v in tags.items():
@@ -219,8 +217,8 @@ def tag_mp3(filename, root_dir, final_name, d, album,
         else:
             cover_image = multi_emb_image
 
-        with open(cover_image, 'rb') as cover:
-            audio.add(id3.APIC(3, 'image/jpeg', 3, '', cover.read()))
+        with open(cover_image, "rb") as cover:
+            audio.add(id3.APIC(3, "image/jpeg", 3, "", cover.read()))
 
-    audio.save(filename, 'v2_version=3')
+    audio.save(filename, "v2_version=3")
     os.rename(filename, final_name)


### PR DESCRIPTION
I've changed all of the formatting to Black, as you suggested. I added a `.flake8` file so that the linter's warnings about line lengths would be suppressed.

There is only one substantive change: I merged the `get_type` and `get_id` functions into one. Scanning the url twice for info seemed repetitive, and the `get_type` function was a bit too hacky.