### PR TITLE
add flag to show configuration and db info

### DIFF
--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -150,6 +150,12 @@ def main():
     if arguments.reset:
         sys.exit(_reset_config(CONFIG_FILE))
 
+    if arguments.show_config:
+        print(f"Configuation: {CONFIG_FILE}\nDatabase: {QOBUZ_DB}\n---")
+        with open(CONFIG_FILE, "r") as f:
+            print(f.read())
+        sys.exit()
+
     if arguments.purge:
         try:
             os.remove(QOBUZ_DB)

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -150,7 +150,7 @@ def qobuz_dl_args(
         help="purge/delete downloaded-IDs database",
     )
     parser.add_argument(
-        "-c",
+        "-sc",
         "--show-config",
         action="store_true",
         help="show configuration",

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -149,6 +149,12 @@ def qobuz_dl_args(
         action="store_true",
         help="purge/delete downloaded-IDs database",
     )
+    parser.add_argument(
+        "-c",
+        "--show-config",
+        action="store_true",
+        help="show configuration",
+    )
 
     subparsers = parser.add_subparsers(
         title="commands",


### PR DESCRIPTION
PR to add a `--show-config`/`-c` flag that prints the config and DB locations, as well as the configuration file content. Useful for users to be able to locate where the files are located, I noticed I had to dig around since it wasn't clear.

Example output (with parts redacted)
```
$ qobuz-dl --show-config
Configuation: /Users/XXXXXXXX/.config/qobuz-dl/config.ini
Database: /Users/XXXXXXXX/.config/qobuz-dl/qobuz_dl.db
---
[DEFAULT]
email = XXXXXXXX
password = XXXXXXXX
default_folder = Qobuz Downloads
default_quality = 6
default_limit = 20
no_m3u = false
albums_only = false
no_fallback = false
og_cover = false
embed_art = false
no_cover = false
no_database = false
app_id = XXXXXXXX
secrets = XXXXXXXX
folder_format = {artist} - {album} ({year}) [{bit_depth}B-{sampling_rate}kHz]
track_format = {tracknumber}. {tracktitle}
smart_discography = false
```

