### PR TITLE
Add featured artists to music tag

### DIFF
--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -47,7 +47,9 @@ class QobuzDL:
         quality_fallback=True,
         cover_og_quality=False,
         no_cover=False,
+        cleanup_cover=True,
         downloads_db=None,
+        overwrite=False,
         folder_format="{artist} - {album} ({year}) [{bit_depth}B-"
         "{sampling_rate}kHz]",
         track_format="{tracknumber}. {tracktitle}",
@@ -64,7 +66,9 @@ class QobuzDL:
         self.quality_fallback = quality_fallback
         self.cover_og_quality = cover_og_quality
         self.no_cover = no_cover
+        self.cleanup_cover = cleanup_cover,
         self.downloads_db = create_db(downloads_db) if downloads_db else None
+        self.overwrite = overwrite
         self.folder_format = folder_format
         self.track_format = track_format
         self.smart_discography = smart_discography
@@ -99,8 +103,10 @@ class QobuzDL:
                 self.quality_fallback,
                 self.cover_og_quality,
                 self.no_cover,
+                self.cleanup_cover,
                 self.folder_format,
                 self.track_format,
+                self.overwrite,
             )
             dloader.download_id_by_type(not album)
             handle_download_id(self.downloads_db, item_id, add_id=True)

--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -41,8 +41,10 @@ class Download:
         downgrade_quality: bool = False,
         cover_og_quality: bool = False,
         no_cover: bool = False,
+        cleanup_cover: bool = True,
         folder_format=None,
         track_format=None,
+        overwrite=False,
     ):
         self.client = client
         self.item_id = item_id
@@ -53,8 +55,10 @@ class Download:
         self.downgrade_quality = downgrade_quality
         self.cover_og_quality = cover_og_quality
         self.no_cover = no_cover
+        self.cleanup_cover = cleanup_cover
         self.folder_format = folder_format or DEFAULT_FOLDER
         self.track_format = track_format or DEFAULT_TRACK
+        self.overwrite = overwrite
 
     def download_id_by_type(self, track=True):
         if not track:
@@ -130,6 +134,12 @@ class Download:
             else:
                 logger.info(f"{OFF}Demo. Skipping")
             count = count + 1
+
+        if self.cleanup_cover:
+            img_path =os.path.join(dirn, "cover.jpg") 
+            if os.path.isfile(img_path):
+                os.remove(img_path)
+
         logger.info(f"{GREEN}Completed")
 
     def download_track(self):
@@ -219,8 +229,11 @@ class Download:
         final_file = os.path.join(root_dir, formatted_path)[:250] + extension
 
         if os.path.isfile(final_file):
-            logger.info(f"{OFF}{track_title} was already downloaded")
-            return
+            if self.overwrite:
+                logger.info(f"{OFF}Overwriting existing file: {track_title}")
+            else:
+                logger.info(f"{OFF}{track_title} was already downloaded")
+                return
 
         tqdm_download(url, filename, filename)
         tag_function = metadata.tag_mp3 if is_mp3 else metadata.tag_flac

--- a/qobuz_dl/metadata.py
+++ b/qobuz_dl/metadata.py
@@ -1,6 +1,7 @@
 import re
 import os
 import logging
+from difflib import SequenceMatcher
 
 from mutagen.flac import FLAC, Picture
 import mutagen.id3 as id3
@@ -32,8 +33,8 @@ ID3_LEGEND = {
 }
 
 FEATURED_ARTIST_TITLES = [
-    "FeaturedArtist",
     "MainArtist",
+    "FeaturedArtist",
 ]
 
 def _get_title(track_dict):
@@ -47,22 +48,19 @@ def _get_title(track_dict):
 
     return title
 
+def _get_featured_artists(artists, track_dict):
+    if not track_dict["performers"]:
+        return
+    performers = [p.split(",",1) for p in track_dict["performers"].split(" - ") if "," in p]
 
-def _get_featured_artists(track_dict):
-    featured_artists = []
-    primary_artist = True
-    for i in track_dict["performers"].split(" - "):
-        # ignore primary artist
-        if primary_artist and "MainArtist" in i:
-            primary_artist = False
-            continue
-
-        for jobtitle in FEATURED_ARTIST_TITLES:
-            if jobtitle in i:
-                featured_artists.append(i.split(",")[0])
-                break
-    return featured_artists
-
+    # list artists in order of their contributions
+    for jobtitle in FEATURED_ARTIST_TITLES:
+        for p,j in performers:
+            if jobtitle in j:
+                # performer is already listed as an artist
+                if any([SequenceMatcher(None, p.lower(), a.lower()).ratio() > 0.6 for a in artists]):
+                    continue
+                artists.append(p)
 
 def _format_copyright(s: str) -> str:
     if s:
@@ -162,7 +160,7 @@ def tag_flac(
     else:
         artists = [artist_ or album["artist"]["name"]]
 
-    artists.extend(_get_featured_artists(d))
+    _get_featured_artists(artists, d)
     audio["ARTIST"] = artists
 
     audio["LABEL"] = album.get("label", {}).get("name", "n/a")
@@ -220,7 +218,7 @@ def tag_mp3(filename, root_dir, final_name, d, album, istrack=True, em_image=Fal
     else:
         artists = [artist_ or album["artist"]["name"]]
     
-    artists.extend(_get_featured_artists(d))
+    _get_featured_artists(artists, d)
     tags["artist"] = artists
 
     if istrack:

--- a/qobuz_dl/metadata.py
+++ b/qobuz_dl/metadata.py
@@ -33,8 +33,11 @@ ID3_LEGEND = {
 }
 
 FEATURED_ARTIST_TITLES = [
-    "MainArtist",
-    "FeaturedArtist",
+    "mainartist",
+    "featuredartist",
+    "featuring",
+    "performedby",
+    "performer",
 ]
 
 def _get_title(track_dict):
@@ -56,9 +59,11 @@ def _get_featured_artists(artists, track_dict):
     # list artists in order of their contributions
     for jobtitle in FEATURED_ARTIST_TITLES:
         for p,j in performers:
-            if jobtitle in j:
+            if " feat" in p.lower():
+                continue
+            if jobtitle in j.lower().replace(" ", ""):
                 # performer is already listed as an artist
-                if any([SequenceMatcher(None, p.lower(), a.lower()).ratio() > 0.6 for a in artists]):
+                if any([p in a or SequenceMatcher(None, p.lower(), a.lower()).ratio() > 0.6 for a in artists]):
                     continue
                 artists.append(p)
 

--- a/qobuz_dl/metadata.py
+++ b/qobuz_dl/metadata.py
@@ -67,6 +67,22 @@ def _get_featured_artists(artists, track_dict):
                     continue
                 artists.append(p)
 
+def _get_featured_artists(track_dict):
+    featured_artists = []
+    primary_artist = True
+    for i in track_dict["performers"].split(" - "):
+        # ignore primary artist
+        if primary_artist and "MainArtist" in i:
+            primary_artist = False
+            continue
+
+        for jobtitle in FEATURED_ARTIST_TITLES:
+            if jobtitle in i:
+                featured_artists.append(i.split(",")[0])
+                break
+    return featured_artists
+
+
 def _format_copyright(s: str) -> str:
     if s:
         s = s.replace("(P)", PHON_COPYRIGHT)
@@ -189,7 +205,7 @@ def tag_flac(
         _embed_flac_img(root_dir, audio)
 
     audio.save()
-    os.rename(filename, final_name)
+    os.replace(filename, final_name)
 
 
 def tag_mp3(filename, root_dir, final_name, d, album, istrack=True, em_image=False):
@@ -255,4 +271,4 @@ def tag_mp3(filename, root_dir, final_name, d, album, istrack=True, em_image=Fal
         _embed_id3_img(root_dir, audio)
 
     audio.save(filename, "v2_version=3")
-    os.rename(filename, final_name)
+    os.replace(filename, final_name)


### PR DESCRIPTION

Featured artists are currently ignored when generating tags. This information can be extracted from the "performers" field of the metadata and appended to the artist field in separate tags.

This solution for extracting featured artists is not as perfect as I would like, but I am building a list of testcases to validate against.