### PR TITLE
Sanitize album and track attributes

### DIFF
--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -254,8 +254,8 @@ class Download:
     @staticmethod
     def _get_track_attr(meta, track_title, bit_depth, sampling_rate):
         return {
-            "album": meta["album"]["title"],
-            "artist": meta["album"]["artist"]["name"],
+            "album": sanitize_filename(meta["album"]["title"]),
+            "artist": sanitize_filename(meta["album"]["artist"]["name"]),
             "tracktitle": track_title,
             "year": meta["album"]["release_date_original"].split("-")[0],
             "bit_depth": bit_depth,
@@ -265,8 +265,8 @@ class Download:
     @staticmethod
     def _get_album_attr(meta, album_title, file_format, bit_depth, sampling_rate):
         return {
-            "artist": meta["artist"]["name"],
-            "album": album_title,
+            "artist": sanitize_filename(meta["artist"]["name"]),
+            "album": sanitize_filename(album_title),
             "year": meta["release_date_original"].split("-")[0],
             "format": file_format,
             "bit_depth": bit_depth,


### PR DESCRIPTION
- Fixes #225
- Fixes #212
- Fixes #207

Now using "sanitize_filename" on the album and artist attributes. Now no accidental subdirectories get created because of characters like: ":" or "/"

sanitize_filepath accepts "/" or sometimes ":" in paths, because a file path can include subdirectories. A file name shouldn't have subdirectories, so they get removed from the path. You can't use sanitize_filename on the entire sanitized_title, since than it removes intentional subdirectories made because of folder_format.