### PR TITLE
Auth by user_id and user_auth_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Type your search query
 ```
 Logging...
 Logged: OK
-Membership: Studio
+Membership: Studio. Expires 10 Sep 2026.
 
 
 Enter your search: [Ctrl + c to quit]

--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -32,7 +32,7 @@ def _reset_config(config_file):
 
     auth_method = input(f"Select authentication method:\n1. Email + password {OFF}(default){RESET}\n2. user_id + user_auth_token\n(Enter 1 or 2) {OFF}(1){RESET}: ")
 
-    if auth_method == "1" or auth_method == "": 
+    if auth_method == "1" or auth_method == "":
         config["DEFAULT"]["use_token"] = "false"
         config["DEFAULT"]["email"] = input("Enter your email:\n- ")
         password = input("Enter your password\n- ")

--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -132,7 +132,7 @@ def main():
     config.read(CONFIG_FILE)
 
     try:
-        use_token = config["DEFAULT"]["use_token"]
+        use_token = config.getboolean("DEFAULT", "use_token")
         user_id = config["DEFAULT"]["user_id"]
         user_auth_token = config["DEFAULT"]["user_auth_token"]
         email = config["DEFAULT"]["email"]
@@ -197,7 +197,7 @@ def main():
         smart_discography=arguments.smart_discography or smart_discography,
     )
 
-    if use_token == "true":
+    if use_token == True:
         qobuz.initialize_client_with_token(app_id, secrets, user_id, user_auth_token)
     else:
         qobuz.initialize_client(email, password, app_id, secrets)

--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -196,7 +196,12 @@ def main():
         track_format=arguments.track_format or track_format,
         smart_discography=arguments.smart_discography or smart_discography,
     )
-    qobuz.initialize_client(email, password, app_id, secrets, use_token, user_id, user_auth_token)
+
+    if use_token == "true":
+        qobuz.initialize_client_with_token(app_id, secrets, user_id, user_auth_token)
+    else:
+        qobuz.initialize_client(email, password, app_id, secrets)
+
 
     _handle_commands(qobuz, arguments)
 

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -69,8 +69,8 @@ class QobuzDL:
         self.track_format = track_format
         self.smart_discography = smart_discography
 
-    def initialize_client(self, email, pwd, app_id, secrets):
-        self.client = qopy.Client(email, pwd, app_id, secrets)
+    def initialize_client(self, email, pwd, app_id, secrets, use_token, user_id, user_auth_token):
+        self.client = qopy.Client(email, pwd, app_id, secrets, use_token, user_id, user_auth_token)
         logger.info(f"{YELLOW}Set max quality: {QUALITIES[int(self.quality)]}\n")
 
     def get_tokens(self):

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -69,8 +69,12 @@ class QobuzDL:
         self.track_format = track_format
         self.smart_discography = smart_discography
 
-    def initialize_client(self, email, pwd, app_id, secrets, use_token, user_id, user_auth_token):
-        self.client = qopy.Client(email, pwd, app_id, secrets, use_token, user_id, user_auth_token)
+    def initialize_client(self, email, pwd, app_id, secrets):
+        self.client = qopy.Client(email, pwd, app_id, secrets, use_token="false", user_id="", user_auth_token="")
+        logger.info(f"{YELLOW}Set max quality: {QUALITIES[int(self.quality)]}\n")
+
+    def initialize_client_with_token(self, app_id, secrets, user_id, user_auth_token):
+        self.client = qopy.Client(email="", pwd="", app_id=app_id, secrets=secrets, use_token="true", user_id=user_id, user_auth_token=user_auth_token)
         logger.info(f"{YELLOW}Set max quality: {QUALITIES[int(self.quality)]}\n")
 
     def get_tokens(self):

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -215,7 +215,7 @@ class QobuzDL:
 
     def search_by_type(self, query, item_type, limit=10, lucky=False):
         if len(query) < 3:
-            logger.info("{RED}Your search query is too short or invalid")
+            logger.info(f"{RED}Your search query is too short or invalid")
             return
 
         possibles = {

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -70,11 +70,11 @@ class QobuzDL:
         self.smart_discography = smart_discography
 
     def initialize_client(self, email, pwd, app_id, secrets):
-        self.client = qopy.Client(email, pwd, app_id, secrets, use_token="false", user_id="", user_auth_token="")
+        self.client = qopy.Client(email, pwd, app_id, secrets, use_token=False, user_id="", user_auth_token="")
         logger.info(f"{YELLOW}Set max quality: {QUALITIES[int(self.quality)]}\n")
 
     def initialize_client_with_token(self, app_id, secrets, user_id, user_auth_token):
-        self.client = qopy.Client(email="", pwd="", app_id=app_id, secrets=secrets, use_token="true", user_id=user_id, user_auth_token=user_auth_token)
+        self.client = qopy.Client(email="", pwd="", app_id=app_id, secrets=secrets, use_token=True, user_id=user_id, user_auth_token=user_auth_token)
         logger.info(f"{YELLOW}Set max quality: {QUALITIES[int(self.quality)]}\n")
 
     def get_tokens(self):

--- a/qobuz_dl/qopy.py
+++ b/qobuz_dl/qopy.py
@@ -44,7 +44,7 @@ class Client:
 
     def api_call(self, epoint, **kwargs):
         if epoint == "user/login":
-            if kwargs["use_token"] == "true":
+            if kwargs["use_token"] == True:
                 params = {
                     "user_id": kwargs["user_id"],
                     "user_auth_token": kwargs["user_auth_token"]

--- a/qobuz_dl/qopy.py
+++ b/qobuz_dl/qopy.py
@@ -5,6 +5,7 @@
 import hashlib
 import logging
 import time
+from datetime import date
 
 import requests
 
@@ -135,7 +136,8 @@ class Client:
         self.uat = usr_info["user_auth_token"]
         self.session.headers.update({"X-User-Auth-Token": self.uat})
         self.label = usr_info["user"]["credential"]["parameters"]["short_label"]
-        logger.info(f"{GREEN}Membership: {self.label}")
+        self.expiry_date = date.fromisoformat(usr_info["user"]["subscription"]["end_date"])
+        logger.info(f"{GREEN}Membership: {self.label}. Expires {date.strftime(self.expiry_date, '%d %b %Y')}.")
 
     def multi_meta(self, epoint, key, id, type):
         total = 1


### PR DESCRIPTION
As mentioned in #161

PR to add alternative way to authenticate and some other small changes.

- Added simple token auth with login method selection menu:
```
Select authentication method:
1. Email + password (default)
2. user_id + user_auth_token
(Enter 1 or 2) (1): 2
Enter your user_id:
- 00000000
Enter your user_auth_token:
- 00000000
...
``` 
- Config file has 3 additional keys `use_token`, `user_id`, `user_auth_token`
- Output expiry date next to membership:
```
Membership: Studio. Expires 16 Sep 2023.
``` 
- Fixed missing logger color in _interactive_ mode

This will break existing installations (will have to reset config), perhaps there is a better approach?