### PR TITLE
add encoding for create m3u file.

### DIFF
--- a/qobuz_dl/utils.py
+++ b/qobuz_dl/utils.py
@@ -69,7 +69,7 @@ def make_m3u(pl_directory):
             track_list.append(index)
 
     if len(track_list) > 1:
-        with open(os.path.join(pl_directory, pl_name), "w", encoding="uf-8") as pl:
+        with open(os.path.join(pl_directory, pl_name), "w", encoding="utf-8") as pl:
             pl.write("\n\n".join(track_list))
 
 


### PR DESCRIPTION
If an album or playlist has a song containing special characters, qobuz-dl cannot create m3u file.