### PR TITLE
update to download unlimit.

### DIFF
--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -151,9 +151,9 @@ class QobuzDL:
                     skip_extras=True,
                 )
             else:
-                items = [item[type_dict["iterable_key"]]["items"] for item in content][
-                    0
-                ]
+                items = []
+                for item in content:
+                    items.extend(item[type_dict["iterable_key"]]["items"])
 
             logger.info(f"{YELLOW}{len(items)} downloads in queue")
             for item in items:


### PR DESCRIPTION
Hello,

I have an update to fix the download limit of 500 songs.

Currently, your tool is able to store all tracks in an album or playlist, but it can only download element [0] of the list which is limited to 500 tracks.

I have made an update that allows all tracks to be stored in the download queue for downloading. 

Please take a moment to review this update.
