### PR TITLE
Ensure cross-platform compatibility by using UTF-8 encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Qobuz Downloads
 __pycache__
+build/
+qobuz_dl.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 Qobuz Downloads
 __pycache__
-build/
+build
 qobuz_dl.egg-info

--- a/qobuz_dl/utils.py
+++ b/qobuz_dl/utils.py
@@ -38,6 +38,7 @@ def make_m3u(pl_directory):
     track_list = ["#EXTM3U"]
     rel_folder = os.path.basename(os.path.normpath(pl_directory))
     pl_name = rel_folder + ".m3u"
+    
     for local, dirs, files in os.walk(pl_directory):
         dirs.sort()
         audio_rel_files = [
@@ -50,6 +51,7 @@ def make_m3u(pl_directory):
             for file_ in files
             if os.path.splitext(file_)[-1] in EXTENSIONS
         ]
+        
         if not audio_files or len(audio_files) != len(audio_rel_files):
             continue
 
@@ -69,7 +71,8 @@ def make_m3u(pl_directory):
             track_list.append(index)
 
     if len(track_list) > 1:
-        with open(os.path.join(pl_directory, pl_name), "w") as pl:
+        m3u_path = os.path.join(pl_directory, pl_name)
+        with open(m3u_path, "w", encoding="utf-8") as pl:
             pl.write("\n\n".join(track_list))
 
 


### PR DESCRIPTION
**Overview:**
This pull request addresses the UnicodeEncodeError encountered on platforms such as Windows due to encoding issues when writing certain files with unsupported characters.

**Changes Made:**
- Explicity use UTF-8 encoding when writing to files, preventing UnicodeEncodeError.

**Why:**
- On Windows, the default encoding 'cp1252' is used and causes issues when writing to files with certain characters.
- Using UTF-8 encoding ensures broader compatibility and resolves the encoding error.

**Testing:**
- Tested on Windows to confirm the resolution of the UnicodeEncodeError.

**Dependencies:**
None.

**Additional Notes:**
- This change improves cross-platform compatibility by resolving the specific encoding issue reported in: https://github.com/vitiko98/qobuz-dl/pull/235.
