### PR TITLE
Download favorites as JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Qobuz Downloads
 __pycache__
+.venv
+.vscode

--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -86,6 +86,8 @@ def _handle_commands(qobuz, arguments):
             qobuz.lucky_type = arguments.type
             qobuz.lucky_limit = arguments.number
             qobuz.lucky_mode(query)
+        elif arguments.command == "favs":
+            qobuz.download_favorites(arguments.directory + "/" + arguments.file)    
         else:
             qobuz.interactive_limit = arguments.limit
             qobuz.interactive()

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -54,6 +54,19 @@ def dl_args(subparsers):
     )
     return download
 
+def favorites_args(subparsers):
+    favs = subparsers.add_parser(
+        "favs",
+        description="Download favorites (albums, tracks and artists) as JSON"
+    )
+    favs.add_argument(
+        "-f",
+        "--file",
+        metavar="PATH",
+        default="favorites.json",
+        help='file name for favorites (default: "favorites.json")',
+    )
+    return favs
 
 def add_common_arg(custom_parser, default_folder, default_quality):
     custom_parser.add_argument(
@@ -165,9 +178,10 @@ def qobuz_dl_args(
     interactive = fun_args(subparsers, default_limit)
     download = dl_args(subparsers)
     lucky = lucky_args(subparsers)
+    favorites = favorites_args(subparsers)
     [
         add_common_arg(i, default_folder, default_quality)
-        for i in (interactive, download, lucky)
+        for i in (interactive, download, lucky, favorites)
     ]
 
     return parser

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -410,10 +410,7 @@ class QobuzDL:
         _call = calls[type]
 
         response = _call(offset,limit)
-        try: 
-            total = response[type]["total"]
-        except KeyError:
-            print("unexpected response for type " + type + ":")
+        total = response[type]["total"]
 
         while len(response[type]["items"]) < total:
             offset += limit

--- a/qobuz_dl/qopy.py
+++ b/qobuz_dl/qopy.py
@@ -77,14 +77,16 @@ class Client:
         elif epoint == "favorite/getUserFavorites":
             unix = time.time()
             # r_sig = "userLibrarygetAlbumsList" + str(unix) + kwargs["sec"]
-            r_sig = "favoritegetUserFavorites" + str(unix) + kwargs["sec"]
+            r_sig = "favoritegetUserFavorites" + str(unix) + kwargs.get("sec", self.sec)
             r_sig_hashed = hashlib.md5(r_sig.encode("utf-8")).hexdigest()
             params = {
                 "app_id": self.id,
                 "user_auth_token": self.uat,
-                "type": "albums",
+                "type": kwargs.get("type", "albums"),
                 "request_ts": unix,
                 "request_sig": r_sig_hashed,
+                "offset": kwargs.get("offset", 0),
+                "limit": kwargs.get("limit", 500)
             }
         elif epoint == "track/getFileUrl":
             unix = time.time()


### PR DESCRIPTION
This PR fixes a small bug in `qopy.py` that prevented fetching favorite tracks and artists (the API call does not take the `type` parameter into account and always fetches the favorite albums instead). 

It also adds a method in the Qobuz core api to download all favorites as a JSON file, and exposes it in the CLI via the `favs` command. This is probably not very helpful for normal usage but it can be useful for post-processing or integration with other tools, or just to keep a local archive of one's favorites for reference.