### PR TITLE
Adding new checks for song title sanification

### DIFF
--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -97,9 +97,13 @@ class Download:
         folder_format, track_format = _clean_format_str(
             self.folder_format, self.track_format, file_format
         )
-        sanitized_title = sanitize_filepath(folder_format.format(**album_attr))
+        # Limiting max length to 128 chars to prevent "OSError" due to too long path
+        sanitized_title = sanitize_filepath(folder_format.format(**album_attr))[:128]
         dirn = os.path.join(self.path, sanitized_title)
-        os.makedirs(dirn, exist_ok=True)
+        try:
+            os.makedirs(dirn, exist_ok=True)
+        except Exception as e:
+            raise NonStreamable(f"This release has a corrupted name, {e}")
 
         if self.no_cover:
             logger.info(f"{OFF}Skipping cover")


### PR DESCRIPTION
Some songs re-published by [very good people] that steal music from others have very poor naming, due to poor choices in SEO. 

    OSError: [Errno 36] File name too long: '/nfs/music/consume/XXXXX/XXXXX - Music to listen to~dance to~blaze to~pray to~feed to~sleep to~talk to~grind to~trip to~breathe to~help to~hurt to~scroll to~roll to~love to~hate to~learn Too~plot to~play to~be to~feel to~breed to~sweat to~dream to~hide to~live to~die to'

I have added a check to limit file name to the 128th character, and gracefully handle the exception if still present. 