### PR TITLE
Fix CDN download resilience & rewrite Qobuz authentication

### DIFF
--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -1,5 +1,4 @@
 import configparser
-import hashlib
 import logging
 import glob
 import os
@@ -30,8 +29,6 @@ def _reset_config(config_file):
     logging.info(f"{YELLOW}Creating config file: {config_file}")
     config = configparser.ConfigParser()
     config["DEFAULT"]["email"] = input("Enter your email:\n- ")
-    password = input("Enter your password\n- ")
-    config["DEFAULT"]["password"] = hashlib.md5(password.encode("utf-8")).hexdigest()
     config["DEFAULT"]["default_folder"] = (
         input("Folder for downloads (leave empty for default 'Qobuz Downloads')\n- ")
         or "Qobuz Downloads"
@@ -54,11 +51,59 @@ def _reset_config(config_file):
     config["DEFAULT"]["no_database"] = "false"
     logging.info(f"{YELLOW}Getting tokens. Please wait...")
     bundle = Bundle()
-    config["DEFAULT"]["app_id"] = str(bundle.get_app_id())
-    config["DEFAULT"]["secrets"] = ",".join(bundle.get_secrets().values())
+    app_id = str(bundle.get_app_id())
+    secrets = list(bundle.get_secrets().values())
+    config["DEFAULT"]["app_id"] = app_id
+    config["DEFAULT"]["secrets"] = ",".join(secrets)
     config["DEFAULT"]["folder_format"] = DEFAULT_FOLDER
     config["DEFAULT"]["track_format"] = DEFAULT_TRACK
     config["DEFAULT"]["smart_discography"] = "false"
+
+    # Try POST login with email/password to get a token
+    import requests
+    email = config["DEFAULT"]["email"]
+    password = input("Enter your Qobuz password:\n- ")
+    token = None
+
+    try:
+        s = requests.Session()
+        s.headers.update({
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) "
+                          "Gecko/20100101 Firefox/83.0",
+            "X-App-Id": app_id,
+        })
+        resp = s.post(
+            "https://www.qobuz.com/api.json/0.2/user/login",
+            data={"email": email, "password": password},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            token = data.get("user_auth_token")
+            if token:
+                logging.info(f"{GREEN}Login successful!")
+            else:
+                logging.warning(f"{YELLOW}Login response had no token.")
+        else:
+            logging.warning(
+                f"{YELLOW}Login returned {resp.status_code}. "
+                "Falling back to manual token entry."
+            )
+    except Exception as e:
+        logging.warning(f"{YELLOW}Login failed: {e}")
+
+    if not token:
+        logging.info(
+            f"{YELLOW}To get a token manually:\n"
+            "  1. Open https://play.qobuz.com and log in\n"
+            "  2. Open DevTools (F12) → Network tab\n"
+            "  3. Look for API requests with user_auth_token in the response\n"
+            '  4. Copy the "user_auth_token" value'
+        )
+        token = input("Paste your user_auth_token:\n- ").strip()
+
+    config["DEFAULT"]["password"] = token
+
     with open(config_file, "w") as configfile:
         config.write(configfile)
     logging.info(

--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -1,5 +1,9 @@
 import logging
 import os
+import shutil
+import ssl
+import time
+import urllib.request
 from typing import Tuple
 
 import requests
@@ -114,6 +118,8 @@ class Download:
         media_numbers = [track["media_number"] for track in meta["tracks"]["items"]]
         is_multiple = True if len([*{*media_numbers}]) > 1 else False
         for i in meta["tracks"]["items"]:
+            if count > 0:
+                time.sleep(1)  # brief pause between tracks to avoid CDN rate limiting
             parse = self.client.get_track_url(i["id"], fmt_id=self.quality)
             if "sample" not in parse and parse["sampling_rate"]:
                 is_mp3 = True if int(self.quality) == 5 else False
@@ -222,7 +228,50 @@ class Download:
             logger.info(f"{OFF}{track_title} was already downloaded")
             return
 
-        tqdm_download(url, filename, filename)
+        max_retries = 5
+        last_error = None
+        for attempt in range(max_retries):
+            if attempt > 0:
+                wait = 2 ** attempt  # 2, 4, 8, 16 seconds
+                logger.warning(
+                    f"{YELLOW}Network error, retrying in {wait}s "
+                    f"(attempt {attempt + 1}/{max_retries})..."
+                )
+                time.sleep(wait)
+                if os.path.isfile(filename):
+                    os.remove(filename)
+                # Re-fetch a fresh download URL — the CDN rejects reused/stale URLs
+                try:
+                    fresh_url_dict = self.client.get_track_url(
+                        track_metadata["id"], fmt_id=self.quality
+                    )
+                    url = fresh_url_dict["url"]
+                except Exception as url_err:
+                    logger.warning(f"{YELLOW}Could not refresh URL: {url_err}")
+            try:
+                tqdm_download(url, filename, filename)
+                break
+            except (
+                requests.exceptions.ChunkedEncodingError,
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                ConnectionError,
+                urllib.error.URLError,
+                OSError,
+            ) as e:
+                last_error = e
+                logger.warning(
+                    f"{YELLOW}Download attempt {attempt + 1} failed: {e}"
+                )
+        else:
+            logger.error(
+                f"{RED}Failed to download {track_title} after {max_retries} "
+                f"attempts (CDN issue). Skipping track..."
+            )
+            if os.path.isfile(filename):
+                os.remove(filename)
+            return
+
         tag_function = metadata.tag_mp3 if is_mp3 else metadata.tag_flac
         try:
             tag_function(
@@ -306,9 +355,27 @@ class Download:
 
 
 def tqdm_download(url, fname, desc):
-    r = requests.get(url, allow_redirects=True, stream=True)
-    total = int(r.headers.get("content-length", 0))
+    logger.debug(f"GET {url[:80]}...")
+    # Use urllib.request instead of requests/urllib3 to work around
+    # IncompleteRead issues with Akamai CDN on large FLAC files
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) "
+                          "Gecko/20100101 Firefox/83.0",
+            "Accept-Encoding": "identity",
+        },
+    )
+    ctx = ssl.create_default_context()
+    resp = urllib.request.urlopen(req, timeout=60, context=ctx)
+    total = int(resp.headers.get("Content-Length", 0))
+    logger.debug(
+        f"Response status: {resp.status} | "
+        f"Content-Type: {resp.headers.get('Content-Type')} | "
+        f"Content-Length: {total}"
+    )
     download_size = 0
+    chunk_size = 64 * 1024  # 64KB
     with open(fname, "wb") as file, tqdm(
         total=total,
         unit="iB",
@@ -317,14 +384,25 @@ def tqdm_download(url, fname, desc):
         desc=desc,
         bar_format=CYAN + "{n_fmt}/{total_fmt} /// {desc}",
     ) as bar:
-        for data in r.iter_content(chunk_size=1024):
-            size = file.write(data)
+        while True:
+            chunk = resp.read(chunk_size)
+            if not chunk:
+                break
+            size = file.write(chunk)
             bar.update(size)
             download_size += size
-
-    if total != download_size:
-        # https://stackoverflow.com/questions/69919912/requests-iter-content-thinks-file-is-complete-but-its-not
-        raise ConnectionError("File download was interrupted for " + fname)
+    resp.close()
+    logger.debug(f"Downloaded {download_size} / {total} bytes for {fname}")
+    if download_size < total:
+        if download_size <= 16:
+            try:
+                with open(fname, "rb") as f:
+                    logger.debug(f"First bytes received: {f.read(16)!r}")
+            except Exception:
+                pass
+        raise ConnectionError(
+            f"Incomplete download ({download_size}/{total} bytes) for {fname}"
+        )
 
 
 def _get_description(item: dict, track_title, multiple=None):

--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -1,9 +1,6 @@
 import logging
 import os
-import shutil
-import ssl
 import time
-import urllib.request
 from typing import Tuple
 
 import requests
@@ -256,7 +253,6 @@ class Download:
                 requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout,
                 ConnectionError,
-                urllib.error.URLError,
                 OSError,
             ) as e:
                 last_error = e
@@ -355,27 +351,9 @@ class Download:
 
 
 def tqdm_download(url, fname, desc):
-    logger.debug(f"GET {url[:80]}...")
-    # Use urllib.request instead of requests/urllib3 to work around
-    # IncompleteRead issues with Akamai CDN on large FLAC files
-    req = urllib.request.Request(
-        url,
-        headers={
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) "
-                          "Gecko/20100101 Firefox/83.0",
-            "Accept-Encoding": "identity",
-        },
-    )
-    ctx = ssl.create_default_context()
-    resp = urllib.request.urlopen(req, timeout=60, context=ctx)
-    total = int(resp.headers.get("Content-Length", 0))
-    logger.debug(
-        f"Response status: {resp.status} | "
-        f"Content-Type: {resp.headers.get('Content-Type')} | "
-        f"Content-Length: {total}"
-    )
+    r = requests.get(url, allow_redirects=True, stream=True, timeout=(10, 60))
+    total = int(r.headers.get("content-length", 0))
     download_size = 0
-    chunk_size = 64 * 1024  # 64KB
     with open(fname, "wb") as file, tqdm(
         total=total,
         unit="iB",
@@ -384,22 +362,11 @@ def tqdm_download(url, fname, desc):
         desc=desc,
         bar_format=CYAN + "{n_fmt}/{total_fmt} /// {desc}",
     ) as bar:
-        while True:
-            chunk = resp.read(chunk_size)
-            if not chunk:
-                break
-            size = file.write(chunk)
+        for data in r.iter_content(chunk_size=1024):
+            size = file.write(data)
             bar.update(size)
             download_size += size
-    resp.close()
-    logger.debug(f"Downloaded {download_size} / {total} bytes for {fname}")
     if download_size < total:
-        if download_size <= 16:
-            try:
-                with open(fname, "rb") as f:
-                    logger.debug(f"First bytes received: {f.read(16)!r}")
-            except Exception:
-                pass
         raise ConnectionError(
             f"Incomplete download ({download_size}/{total} bytes) for {fname}"
         )

--- a/qobuz_dl/qopy.py
+++ b/qobuz_dl/qopy.py
@@ -2,8 +2,10 @@
 # of qopy, originally written by Sorrow446. All credits to the
 # original author.
 
+import configparser
 import hashlib
 import logging
+import os
 import time
 
 import requests
@@ -20,6 +22,12 @@ from qobuz_dl.color import GREEN, YELLOW
 RESET = "Reset your credentials with 'qobuz-dl -r'"
 
 logger = logging.getLogger(__name__)
+
+if os.name == "nt":
+    _OS_CONFIG = os.environ.get("APPDATA")
+else:
+    _OS_CONFIG = os.path.join(os.environ["HOME"], ".config")
+_CONFIG_FILE = os.path.join(_OS_CONFIG, "qobuz-dl", "config.ini")
 
 
 class Client:
@@ -123,13 +131,92 @@ class Client:
         return r.json()
 
     def auth(self, email, pwd):
-        usr_info = self.api_call("user/login", email=email, pwd=pwd)
-        if not usr_info["user"]["credential"]["parameters"]:
-            raise IneligibleError("Free accounts are not eligible to download tracks.")
-        self.uat = usr_info["user_auth_token"]
+        # If pwd looks like a raw password (short, not a long token), try
+        # POST login first to exchange it for a user_auth_token.
+        if len(pwd) < 60:
+            token = self._login_with_password(email, pwd)
+            if token:
+                pwd = token
+                self._save_token(token)
+                logger.info(f"{GREEN}Logged in via email/password.")
+
+        self.uat = pwd
         self.session.headers.update({"X-User-Auth-Token": self.uat})
-        self.label = usr_info["user"]["credential"]["parameters"]["short_label"]
-        logger.info(f"{GREEN}Membership: {self.label}")
+        try:
+            resp = self.session.get(self.base + "user/get")
+            if resp.status_code == 401:
+                raise AuthenticationError(
+                    "Token expired or invalid. Run 'qobuz-dl -r' to "
+                    "log in again.\n" + RESET
+                )
+            resp.raise_for_status()
+            usr_info = resp.json()
+            if "id" not in usr_info:
+                raise AuthenticationError(
+                    "Token expired or invalid. Run 'qobuz-dl -r' to "
+                    "log in again.\n" + RESET
+                )
+            # Refresh token if the API returns a new one
+            new_token = usr_info.get("user_auth_token")
+            if new_token and new_token != self.uat:
+                self.uat = new_token
+                self.session.headers.update({"X-User-Auth-Token": self.uat})
+                self._save_token(new_token)
+                logger.info(f"{GREEN}Auth token refreshed and saved.")
+            # Response is flat — credential is at top level, not under "user"
+            cred = usr_info.get("credential", {})
+            params = cred.get("parameters")
+            if not params:
+                raise IneligibleError(
+                    "Free accounts are not eligible to download tracks."
+                )
+            self.label = params.get("short_label", "Unknown")
+            logger.info(f"{GREEN}Logged: OK")
+            logger.info(f"{GREEN}Membership: {self.label}")
+        except (KeyError, requests.exceptions.RequestException) as e:
+            raise AuthenticationError(
+                f"Auth failed: {e}. Run 'qobuz-dl -r' to log in "
+                "again.\n" + RESET
+            )
+
+    def _login_with_password(self, email, password):
+        """POST form-encoded login to get a user_auth_token.
+
+        Returns the token string on success, or None on failure.
+        """
+        try:
+            resp = self.session.post(
+                self.base + "user/login",
+                data={"email": email, "password": password},
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    f"{YELLOW}POST login returned {resp.status_code}: "
+                    f"{resp.text[:200]}"
+                )
+                return None
+            data = resp.json()
+            token = data.get("user_auth_token")
+            if not token:
+                logger.warning(f"{YELLOW}No token in login response.")
+                return None
+            return token
+        except Exception as e:
+            logger.warning(f"{YELLOW}POST login failed: {e}")
+            return None
+
+    @staticmethod
+    def _save_token(token):
+        """Save refreshed auth token back to config.ini."""
+        try:
+            config = configparser.ConfigParser()
+            config.read(_CONFIG_FILE)
+            config["DEFAULT"]["password"] = token
+            with open(_CONFIG_FILE, "w") as f:
+                config.write(f)
+        except Exception as e:
+            logger.warning(f"{YELLOW}Could not save refreshed token: {e}")
 
     def multi_meta(self, epoint, key, id, type):
         total = 1


### PR DESCRIPTION
When downloading large Hi-Res FLAC files (e.g. 24-bit/96kHz), the Akamai CDN
occasionally drops the connection after delivering only 1 byte. This causes
IncompleteRead / ChunkedEncodingError exceptions that abort the entire
album download with no recovery. Additionally, Qobuz deprecated the old
GET-based `user/login` endpoint and the browser-based OAuth redirect flow
requires Qobuz to whitelist redirect URLs, which doesn't work for local CLI
apps — making it impossible to log in without manually copying a token from
DevTools.

The CDN issue is server-side — confirmed via curl that specific files can be
persistently broken on a regional edge node while other tracks from the same
album download fine.

## Changes

### qobuz_dl/downloader.py

- **Retry with exponential backoff:** Track downloads now retry up to 5 times
  with increasing delays (2s, 4s, 8s, 16s) before giving up.
- **Fresh URL on retry:** Each retry re-fetches the download URL via
  `get_track_url()`, since Akamai rejects reused/stale signed URLs.
- **Graceful skip:** If all retries fail, the track is skipped with an error
  log instead of aborting the entire album. The partial .tmp file is cleaned up.
- **Connection timeout:** Added `timeout=(10, 60)` to the download request
  (10s connect, 60s read) to prevent indefinite hangs.
- **Inter-track delay:** Added a 1-second pause between consecutive track
  downloads to reduce CDN throttling on large albums.

### qobuz_dl/qopy.py — Authentication rewrite

Qobuz deprecated the old GET-based `user/login` endpoint. Auth has been
rewritten to support two flows:

- **POST form-encoded login:** New `_login_with_password()` method sends a
  standard POST to `user/login` with email and password (matching the web
  player's own login mechanism). Returns a `user_auth_token` on success.
- **Auto-detect password vs token:** `auth()` checks if the stored credential
  is a short password (< 60 chars) or a long token, and tries POST login first
  when it looks like a password. Existing token-based configs continue to work
  unchanged.
- **Token validation via `user/get`:** After obtaining a token (either from
  POST login or config), validates it against the `user/get` endpoint. Handles
  the flat response structure (credential at top level, not nested under
  `"user"`).
- **Auto-refresh:** If the API returns a new `user_auth_token`, it is
  persisted back to `config.ini` automatically.

### qobuz_dl/cli.py — Config wizard update

- **Password prompt:** `qobuz-dl -r` now asks for your actual Qobuz password
  and attempts POST login to obtain a token automatically.
- **Fallback to manual token:** If POST login fails (e.g. Qobuz adds
  reCAPTCHA in the future), falls back to manual `user_auth_token` paste with
  instructions.
- **Removed OAuth browser flow:** The browser-based OAuth redirect flow
  (`oauth.py`) has been removed — it required Qobuz to whitelist the redirect
  URL, which doesn't work for local CLI apps.