### PR TITLE
feat: token-based auth (replace deprecated email/password login)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 Qobuz Downloads
 __pycache__
+*.pyc
+*.egg-info/
+.venv/
+.pytest_cache/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # qobuz-dl
-Search, explore and download Lossless and Hi-Res music from [Qobuz](https://www.qobuz.com/). It *just works*™ (2025).
+Search, explore and download Lossless and Hi-Res music from [Qobuz](https://www.qobuz.com/).
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VZWSWVGZGJRMU&source=url)
+
+> **Status (2026-04):** Email/password login was disabled by Qobuz
+> server-side in April 2026. This branch replaces it with **token-based
+> login** (`user_id` + `user_auth_token` captured from `play.qobuz.com`).
+>
+> Downloads have been verified end-to-end on a Studio account
+> (2026-04-26, FLAC 16/44.1). Some accounts may hit
+> `InvalidAppSecretError` from a partial Qobuz signing rollout
+> (MD5 → SHA-256 keyed by an HKDF-derived value); the CLI exits cleanly
+> with code 3 and a pointer back here in that case rather than
+> tracebacking. If you hit this, please open an issue with your account
+> region/tier so we can confirm scope.
 
 ## Features
 
@@ -30,7 +42,24 @@ pip3 install --upgrade qobuz-dl
 pip3 install windows-curses
 pip3 install --upgrade qobuz-dl
 ```
-#### Run qobuz-dl and enter your credentials
+#### Capture your token from play.qobuz.com
+Email/password login was disabled by Qobuz in April 2026. You now need
+to copy a `user_id` and `user_auth_token` from a logged-in browser
+session.
+
+1. Open <https://play.qobuz.com> in your browser and log in.
+2. Open DevTools (F12) → **Console** tab.
+3. Paste and press Enter:
+   ```js
+   JSON.parse(localStorage.getItem('localuser'))
+   ```
+4. Copy the `id` and `user_auth_token` fields from the result.
+
+(Fallback if the console is disabled: **Application** → **Local Storage**
+→ `https://play.qobuz.com` → click the `localuser` row. The value is a
+JSON blob with the same `id` and `user_auth_token` fields.)
+
+#### Run qobuz-dl and paste your token
 ##### Linux / MAC OS
 ```
 qobuz-dl
@@ -39,8 +68,12 @@ qobuz-dl
 ```
 qobuz-dl.exe
 ```
+The first run will prompt for `user_id` and `user_auth_token` and
+store them at `~/.config/qobuz-dl/config.ini` (mode `0600` on POSIX).
 
 > If something fails, run `qobuz-dl -r` to reset your config file.
+> Run `qobuz-dl --show-config` to inspect the current config (secrets
+> are redacted by default; pass `--show-secrets` to reveal them).
 
 ## Examples
 
@@ -149,8 +182,10 @@ commands:
     lucky         lucky mode
 ```
 
-## Module usage 
-Using `qobuz-dl` as a module is really easy. Basically, the only thing you need is `QobuzDL` from `core`.
+## Module usage
+Using `qobuz-dl` as a module is straightforward. The only thing you need
+is `QobuzDL` from `core` plus a `user_id` + `user_auth_token` pair
+captured from `play.qobuz.com` (see the *Getting started* section).
 
 ```python
 import logging
@@ -158,15 +193,21 @@ from qobuz_dl.core import QobuzDL
 
 logging.basicConfig(level=logging.INFO)
 
-email = "your@email.com"
-password = "your_password"
+user_id = "3394846"
+user_auth_token = "your-token-here"
 
 qobuz = QobuzDL()
-qobuz.get_tokens() # get 'app_id' and 'secrets' attrs
-qobuz.initialize_client(email, password, qobuz.app_id, qobuz.secrets)
+qobuz.get_tokens()  # populate qobuz.app_id and qobuz.secrets from bundle.js
+qobuz.initialize_client_with_token(
+    user_id, user_auth_token, qobuz.app_id, qobuz.secrets
+)
 
 qobuz.handle_url("https://play.qobuz.com/album/va4j3hdlwaubc")
 ```
+
+> The pre-2026 `Client(email, pwd, app_id, secrets)` constructor and
+> `QobuzDL.initialize_client(email, pwd, ...)` were removed in 0.9.10.0.
+> Call `Client.from_token(...)` / `QobuzDL.initialize_client_with_token(...)`.
 
 Attributes, methods and parameters have been named as self-explanatory as possible.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra --strict-markers

--- a/qobuz_dl/__init__.py
+++ b/qobuz_dl/__init__.py
@@ -1,2 +1,18 @@
+"""Public package surface for qobuz-dl.
+
+Migration note (0.9.10.0): the legacy `Client(email, pwd, app_id, secrets)`
+constructor was removed because Qobuz disabled email/password auth
+server-side in April 2026. Use `Client.from_token(...)` instead.
+The legacy `QobuzDL.initialize_client(...)` was renamed to
+`initialize_client_with_token(...)`.
+
+If you were importing `qobuz_dl.Client` directly, the constructor now
+takes `(app_id, secrets)` and does not authenticate; call
+`Client.from_token(user_id, user_auth_token, app_id, secrets)` to get a
+ready-to-use client.
+"""
+
 from .qopy import Client
 from .cli import main
+
+__all__ = ["Client", "main"]

--- a/qobuz_dl/_config_io.py
+++ b/qobuz_dl/_config_io.py
@@ -1,0 +1,60 @@
+"""Atomic config writer used for `~/.config/qobuz-dl/config.ini`.
+
+The config holds a long-lived `user_auth_token`; a partial write would
+corrupt the only credentials store on disk. Idiom:
+
+  1. tempfile.NamedTemporaryFile in the *same directory* as the target
+  2. parser.write(...), flush, fsync the file fd
+  3. close before os.replace (required on Windows)
+  4. os.replace (atomic on POSIX; works on Windows too)
+  5. chmod 0o600 on POSIX (no-op on Windows)
+  6. fsync the parent directory on POSIX so the rename's directory entry
+     is durable across power loss
+  7. on any exception before os.replace: best-effort unlink the temp file,
+     then re-raise
+"""
+
+import contextlib
+import os
+import tempfile
+
+
+def atomic_write_config(path, parser):
+    target_dir = os.path.dirname(os.path.abspath(path)) or "."
+    os.makedirs(target_dir, exist_ok=True)
+
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=target_dir,
+        prefix=".config-",
+        suffix=".tmp",
+        delete=False,
+    )
+    tmp_name = tmp.name
+    try:
+        parser.write(tmp)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        os.replace(tmp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.close()
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+    if os.name != "nt":
+        os.chmod(path, 0o600)
+        # Make the rename's directory entry durable across power loss.
+        # Best-effort: some filesystems (e.g. cifs) reject directory fsync.
+        try:
+            dirfd = os.open(target_dir, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            with contextlib.suppress(OSError):
+                os.fsync(dirfd)
+        finally:
+            os.close(dirfd)

--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -1,20 +1,39 @@
 import configparser
-import hashlib
+import getpass
+import io
 import logging
 import glob
 import os
+import re
 import sys
 
+from qobuz_dl._config_io import atomic_write_config
 from qobuz_dl.bundle import Bundle
 from qobuz_dl.color import GREEN, RED, YELLOW
 from qobuz_dl.commands import qobuz_dl_args
 from qobuz_dl.core import QobuzDL
 from qobuz_dl.downloader import DEFAULT_FOLDER, DEFAULT_TRACK
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(message)s",
+from qobuz_dl.exceptions import (
+    AuthenticationError,
+    IneligibleError,
+    InvalidAppIdError,
+    InvalidAppSecretError,
 )
+
+logger = logging.getLogger(__name__)
+
+TOKEN_CAPTURE_INSTRUCTIONS = """\
+To get your user_id and user_auth_token:
+  1. Open https://play.qobuz.com in your browser and log in.
+  2. Open DevTools (F12) -> Console tab.
+  3. Paste this and press Enter:
+         JSON.parse(localStorage.getItem('localuser'))
+  4. Copy the `id` and `user_auth_token` fields from the result.
+
+Fallback (if console is disabled): DevTools -> Application tab ->
+Local Storage -> https://play.qobuz.com -> click the `localuser` row.
+The value is a JSON blob with the same `id` and `user_auth_token` fields.
+"""
 
 if os.name == "nt":
     OS_CONFIG = os.environ.get("APPDATA")
@@ -27,23 +46,30 @@ QOBUZ_DB = os.path.join(CONFIG_PATH, "qobuz_dl.db")
 
 
 def _reset_config(config_file):
-    logging.info(f"{YELLOW}Creating config file: {config_file}")
-    config = configparser.ConfigParser()
-    config["DEFAULT"]["email"] = input("Enter your email:\n- ")
-    password = input("Enter your password\n- ")
-    config["DEFAULT"]["password"] = hashlib.md5(password.encode("utf-8")).hexdigest()
-    config["DEFAULT"]["default_folder"] = (
-        input("Folder for downloads (leave empty for default 'Qobuz Downloads')\n- ")
+    logger.info(f"{YELLOW}Creating config file: {config_file}")
+    print(TOKEN_CAPTURE_INSTRUCTIONS)
+    user_id = input("user_id: ").strip()
+    # getpass keeps the token out of terminal scrollback / tmux buffers /
+    # screen-share. Cross-platform: termios on POSIX, msvcrt on Windows.
+    user_auth_token = getpass.getpass("user_auth_token (input hidden): ").strip()
+
+    default_folder = (
+        input("Folder for downloads (leave empty for default 'Qobuz Downloads'): ")
         or "Qobuz Downloads"
     )
-    config["DEFAULT"]["default_quality"] = (
+    default_quality = (
         input(
             "Download quality (5, 6, 7, 27) "
-            "[320, LOSSLESS, 24B <96KHZ, 24B >96KHZ]"
-            "\n(leave empty for default '6')\n- "
+            "[320, LOSSLESS, 24B <96KHZ, 24B >96KHZ] (leave empty for default '6'): "
         )
         or "6"
     )
+
+    config = configparser.ConfigParser()
+    config["DEFAULT"]["user_id"] = user_id
+    config["DEFAULT"]["user_auth_token"] = user_auth_token
+    config["DEFAULT"]["default_folder"] = default_folder
+    config["DEFAULT"]["default_quality"] = default_quality
     config["DEFAULT"]["default_limit"] = "20"
     config["DEFAULT"]["no_m3u"] = "false"
     config["DEFAULT"]["albums_only"] = "false"
@@ -52,16 +78,17 @@ def _reset_config(config_file):
     config["DEFAULT"]["embed_art"] = "false"
     config["DEFAULT"]["no_cover"] = "false"
     config["DEFAULT"]["no_database"] = "false"
-    logging.info(f"{YELLOW}Getting tokens. Please wait...")
+
+    logger.info(f"{YELLOW}Fetching app_id and secrets from play.qobuz.com bundle...")
     bundle = Bundle()
     config["DEFAULT"]["app_id"] = str(bundle.get_app_id())
     config["DEFAULT"]["secrets"] = ",".join(bundle.get_secrets().values())
     config["DEFAULT"]["folder_format"] = DEFAULT_FOLDER
     config["DEFAULT"]["track_format"] = DEFAULT_TRACK
     config["DEFAULT"]["smart_discography"] = "false"
-    with open(config_file, "w") as configfile:
-        config.write(configfile)
-    logging.info(
+
+    atomic_write_config(config_file, config)
+    logger.info(
         f"{GREEN}Config file updated. Edit more options in {config_file}"
         "\nso you don't have to call custom flags every time you run "
         "a qobuz-dl command."
@@ -90,8 +117,19 @@ def _handle_commands(qobuz, arguments):
             qobuz.interactive_limit = arguments.limit
             qobuz.interactive()
 
+    except InvalidAppSecretError:
+        # Belt-and-braces: the pre-flight `client.sec is None` guard in
+        # main() catches the common case, but if Qobuz only rejects a
+        # secret mid-download (e.g. partial server-side rollout), this
+        # ensures the user sees a clean exit instead of a traceback.
+        sys.stderr.write(
+            f"{RED}Downloads currently fail: Qobuz changed their request-"
+            "signing scheme in April 2026. See README.\n"
+        )
+        sys.exit(3)
+
     except KeyboardInterrupt:
-        logging.info(
+        logger.info(
             f"{RED}Interrupted by user\n{YELLOW}Already downloaded items will "
             "be skipped if you try to download the same releases again."
         )
@@ -109,18 +147,117 @@ def _initial_checks():
         sys.exit(qobuz_dl_args().print_help())
 
 
+_REDACTED_KEYS = frozenset({"user_auth_token", "secrets", "password"})
+_REDACTION_SENTINEL = "***REDACTED***"
+
+
+def _redact_config_text(text):
+    """Return `text` with secret-bearing config values replaced.
+
+    Round-trips through `configparser` (rather than regex on lines) so
+    that multi-line continuation values for sensitive keys get fully
+    redacted, not just their first line. Targets `user_auth_token`,
+    `secrets`, and the legacy `password` key. `app_id` is intentionally
+    left visible (it's public — embedded in play.qobuz.com's bundle.js).
+    """
+    parser = configparser.ConfigParser()
+    try:
+        parser.read_string(text)
+    except configparser.Error:
+        # Fall back to regex over lines so we still redact best-effort
+        # rather than echoing a malformed config raw.
+        pattern = re.compile(
+            r"^(\s*(?:" + "|".join(sorted(_REDACTED_KEYS)) + r")\s*=\s*).+$",
+            re.MULTILINE | re.IGNORECASE,
+        )
+        return pattern.sub(r"\1" + _REDACTION_SENTINEL, text)
+
+    for section in (parser.default_section, *parser.sections()):
+        for key in list(parser[section]):
+            if key.lower() in _REDACTED_KEYS and parser[section][key]:
+                parser[section][key] = _REDACTION_SENTINEL
+
+    buf = io.StringIO()
+    parser.write(buf)
+    return buf.getvalue()
+
+
+_LEGACY_AUTH_MIGRATION_MSG = (
+    f"{RED}Email/password authentication is no longer supported by Qobuz "
+    "(deprecated server-side in April 2026).\n"
+    f"{YELLOW}Run `qobuz-dl --reset` to set up token-based login (you'll "
+    "need user_id and user_auth_token from play.qobuz.com).\n"
+)
+
+_NO_CREDENTIALS_MSG = (
+    f"{RED}No credentials found in config.\n"
+    f"{YELLOW}Run `qobuz-dl --reset` to enter your user_id and user_auth_token.\n"
+)
+
+_CORRUPT_CONFIG_MSG = (
+    f"{RED}Config file is corrupt or missing required keys ({{error_type}}).\n"
+    f"{YELLOW}Run `qobuz-dl --reset` to recreate it, or `qobuz-dl --show-config` "
+    "to inspect (secrets redacted).\n"
+)
+
+
+def _show_config(show_secrets):
+    """Print CONFIG_FILE to stdout. Used by --show-config; deliberately
+    independent of the strict config-load so it works even when the
+    config is corrupt (the case users most need it for)."""
+    print(f"Configuration: {CONFIG_FILE}\nDatabase: {QOBUZ_DB}\n---")
+    try:
+        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+            text = f.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        sys.stderr.write(f"{RED}Could not read config file: {type(exc).__name__}\n")
+        sys.exit(2)
+    if not show_secrets:
+        text = _redact_config_text(text)
+    print(text)
+
+
+def _purge_db():
+    try:
+        os.remove(QOBUZ_DB)
+    except FileNotFoundError:
+        pass
+    sys.exit(f"{GREEN}The database was deleted.")
+
+
 def main():
+    # Configure root logger here (not at module import) so importing
+    # `qobuz_dl` as a library doesn't clobber the caller's logging setup.
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
     _initial_checks()
 
-    config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
+    arguments = qobuz_dl_args().parse_args()
 
+    # Maintenance flags must work BEFORE the strict config-load, so a user
+    # with a corrupt config can still --reset / --show-config / --purge to
+    # diagnose and recover.
+    if arguments.reset:
+        sys.exit(_reset_config(CONFIG_FILE))
+
+    if arguments.show_config:
+        _show_config(arguments.show_secrets)
+        sys.exit()
+
+    if arguments.purge:
+        _purge_db()
+
+    config = configparser.ConfigParser()
     try:
-        email = config["DEFAULT"]["email"]
-        password = config["DEFAULT"]["password"]
-        default_folder = config["DEFAULT"]["default_folder"]
-        default_limit = config["DEFAULT"]["default_limit"]
-        default_quality = config["DEFAULT"]["default_quality"]
+        config.read(CONFIG_FILE, encoding="utf-8")
+        defaults = config["DEFAULT"]
+        user_id = defaults.get("user_id", "")
+        user_auth_token = defaults.get("user_auth_token", "")
+        legacy_email = defaults.get("email", "")
+        legacy_password = defaults.get("password", "")
+        default_folder = defaults["default_folder"]
+        default_limit = defaults["default_limit"]
+        default_quality = defaults["default_quality"]
         no_m3u = config.getboolean("DEFAULT", "no_m3u")
         albums_only = config.getboolean("DEFAULT", "albums_only")
         no_fallback = config.getboolean("DEFAULT", "no_fallback")
@@ -128,40 +265,33 @@ def main():
         embed_art = config.getboolean("DEFAULT", "embed_art")
         no_cover = config.getboolean("DEFAULT", "no_cover")
         no_database = config.getboolean("DEFAULT", "no_database")
-        app_id = config["DEFAULT"]["app_id"]
+        app_id = defaults["app_id"]
         smart_discography = config.getboolean("DEFAULT", "smart_discography")
-        folder_format = config["DEFAULT"]["folder_format"]
-        track_format = config["DEFAULT"]["track_format"]
+        folder_format = defaults["folder_format"]
+        track_format = defaults["track_format"]
+        secrets = [s for s in defaults["secrets"].split(",") if s]
+    except (KeyError, ValueError, UnicodeDecodeError, configparser.Error) as error:
+        # KeyError: required option missing.
+        # ValueError: getboolean() / int() coercion failed (e.g. no_cover = maybe).
+        # UnicodeDecodeError: non-UTF-8 bytes in the file (e.g. saved by a
+        #   Windows editor with cp1252) — caught here because configparser's
+        #   parsing error includes the offending source line.
+        # configparser.Error: malformed INI syntax (ParsingError, etc.) —
+        #   its str() can echo the offending line, which may include a
+        #   `user_auth_token = ...` value, so we ONLY surface the type.
+        sys.stderr.write(_CORRUPT_CONFIG_MSG.format(error_type=type(error).__name__))
+        sys.exit(2)
 
-        secrets = [
-            secret for secret in config["DEFAULT"]["secrets"].split(",") if secret
-        ]
-        arguments = qobuz_dl_args(
-            default_quality, default_limit, default_folder
-        ).parse_args()
-    except (KeyError, UnicodeDecodeError, configparser.Error) as error:
-        arguments = qobuz_dl_args().parse_args()
-        if not arguments.reset:
-            sys.exit(
-                f"{RED}Your config file is corrupted: {error}! "
-                "Run 'qobuz-dl -r' to fix this."
-            )
+    # Re-parse args with config defaults applied.
+    arguments = qobuz_dl_args(default_quality, default_limit, default_folder).parse_args()
 
-    if arguments.reset:
-        sys.exit(_reset_config(CONFIG_FILE))
-
-    if arguments.show_config:
-        print(f"Configuation: {CONFIG_FILE}\nDatabase: {QOBUZ_DB}\n---")
-        with open(CONFIG_FILE, "r") as f:
-            print(f.read())
-        sys.exit()
-
-    if arguments.purge:
-        try:
-            os.remove(QOBUZ_DB)
-        except FileNotFoundError:
-            pass
-        sys.exit(f"{GREEN}The database was deleted.")
+    # Auth dispatch: token > legacy email/password > nothing.
+    if not (user_id and user_auth_token):
+        if legacy_email or legacy_password:
+            sys.stderr.write(_LEGACY_AUTH_MIGRATION_MSG)
+        else:
+            sys.stderr.write(_NO_CREDENTIALS_MSG)
+        sys.exit(2)
 
     qobuz = QobuzDL(
         arguments.directory,
@@ -169,7 +299,7 @@ def main():
         arguments.embed_art or embed_art,
         ignore_singles_eps=arguments.albums_only or albums_only,
         no_m3u_for_playlists=arguments.no_m3u or no_m3u,
-        quality_fallback=not arguments.no_fallback or not no_fallback,
+        quality_fallback=not (arguments.no_fallback or no_fallback),
         cover_og_quality=arguments.og_cover or og_cover,
         no_cover=arguments.no_cover or no_cover,
         downloads_db=None if no_database or arguments.no_db else QOBUZ_DB,
@@ -177,7 +307,27 @@ def main():
         track_format=arguments.track_format or track_format,
         smart_discography=arguments.smart_discography or smart_discography,
     )
-    qobuz.initialize_client(email, password, app_id, secrets)
+    try:
+        qobuz.initialize_client_with_token(user_id, user_auth_token, app_id, secrets)
+    except (AuthenticationError, InvalidAppIdError, IneligibleError) as exc:
+        # The qopy AuthenticationError messages are deliberately scrubbed
+        # of token-bearing URLs and already point users at --reset, so str(exc)
+        # is safe to echo. Avoids tracebacks for the very common "stale token"
+        # case (tokens are long-lived but server-revocable).
+        sys.stderr.write(f"{RED}{exc}\n")
+        sys.exit(2)
+
+    if arguments.command in {"dl", "fun", "lucky"} and getattr(
+        qobuz.client, "sec", None
+    ) is None:
+        sys.stderr.write(
+            f"{RED}Downloads currently fail: Qobuz changed their request-"
+            "signing scheme in April 2026 and qobuz-dl hasn't reimplemented "
+            "the new SHA-256 + HKDF signing yet.\n"
+            f"{YELLOW}Login and metadata/search work; downloads do not. "
+            "See the README for the tracking issue.\n"
+        )
+        sys.exit(3)
 
     _handle_commands(qobuz, arguments)
 

--- a/qobuz_dl/commands.py
+++ b/qobuz_dl/commands.py
@@ -153,7 +153,13 @@ def qobuz_dl_args(
         "-sc",
         "--show-config",
         action="store_true",
-        help="show configuration",
+        help="show configuration (with secrets redacted)",
+    )
+    parser.add_argument(
+        "-S",
+        "--show-secrets",
+        action="store_true",
+        help="reveal secrets in --show-config output (default: redacted)",
     )
 
     subparsers = parser.add_subparsers(

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -69,8 +69,8 @@ class QobuzDL:
         self.track_format = track_format
         self.smart_discography = smart_discography
 
-    def initialize_client(self, email, pwd, app_id, secrets):
-        self.client = qopy.Client(email, pwd, app_id, secrets)
+    def initialize_client_with_token(self, user_id, user_auth_token, app_id, secrets):
+        self.client = qopy.Client.from_token(user_id, user_auth_token, app_id, secrets)
         logger.info(f"{YELLOW}Set max quality: {QUALITIES[int(self.quality)]}\n")
 
     def get_tokens(self):

--- a/qobuz_dl/qopy.py
+++ b/qobuz_dl/qopy.py
@@ -22,9 +22,40 @@ RESET = "Reset your credentials with 'qobuz-dl -r'"
 logger = logging.getLogger(__name__)
 
 
+_DOWNLOAD_BROKEN_WARNING = (
+    "Could not validate any app secret. Qobuz changed their request-signing "
+    "scheme in April 2026 and downloads will fail until that's reimplemented. "
+    "Login and metadata/search still work. See the README for details."
+)
+
+# Network timeouts: (connect_seconds, read_seconds). All session.get/post
+# calls in this module pass this so a stalled Qobuz endpoint can never
+# hang the CLI indefinitely.
+_REQUEST_TIMEOUT = (5, 30)
+
+
+def _extract_label(usr_info):
+    """Best-effort membership label extraction.
+
+    Order: credential.parameters.short_label, credential.parameters.label,
+    credential.label. Falls back to "Unknown" rather than KeyError so a
+    minor response-shape change doesn't break login.
+    """
+    credential = usr_info.get("user", {}).get("credential", {}) or {}
+    params = credential.get("parameters") or {}
+    return (
+        params.get("short_label")
+        or params.get("label")
+        or credential.get("label")
+        or "Unknown"
+    )
+
+
 class Client:
-    def __init__(self, email, pwd, app_id, secrets):
-        logger.info(f"{YELLOW}Logging...")
+    def __init__(self, app_id, secrets):
+        # Email/password login was disabled server-side in April 2026.
+        # The constructor only sets up state; callers MUST authenticate via
+        # `Client.from_token(...)`.
         self.secrets = secrets
         self.id = str(app_id)
         self.session = requests.Session()
@@ -32,23 +63,89 @@ class Client:
             {
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0",
                 "X-App-Id": self.id,
-                "Content-Type": "application/json;charset=UTF-8"
-
+                "Content-Type": "application/json;charset=UTF-8",
             }
         )
         self.base = "https://www.qobuz.com/api.json/0.2/"
         self.sec = None
-        self.auth(email, pwd)
-        self.cfg_setup()
+        self.uat = None
+        self.label = None
+
+    @classmethod
+    def from_token(cls, user_id, user_auth_token, app_id, secrets):
+        """Authenticate via Qobuz's token-login endpoint and return a
+        ready-to-use Client. Raises:
+          - AuthenticationError on 401 or unexpected response shape
+          - InvalidAppIdError on 400
+          - IneligibleError when the account has no streaming entitlements
+
+        cfg_setup() failure is downgraded to a logged warning. Both the
+        narrow `InvalidAppSecretError` (every secret rejected by the new
+        signing scheme) and broader transport-level errors during the
+        secret probe are tolerated so login + metadata/search keep working
+        even when the download endpoint is misbehaving.
+        """
+        client = cls(app_id, secrets)
+        client._authenticate_with_token(user_id, user_auth_token)
+        try:
+            client.cfg_setup()
+        except (InvalidAppSecretError, requests.RequestException, ValueError):
+            logger.warning(f"{YELLOW}{_DOWNLOAD_BROKEN_WARNING}")
+        return client
+
+    def _authenticate_with_token(self, user_id, user_auth_token):
+        logger.info(f"{YELLOW}Logging in...")
+        params = {
+            "user_id": str(user_id),
+            "user_auth_token": user_auth_token,
+            "app_id": self.id,
+        }
+        try:
+            r = self.session.get(
+                self.base + "user/login",
+                params=params,
+                timeout=_REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as exc:
+            # Strip URL-bearing details: the token is in the query string
+            # and exc.request.url contains it verbatim.
+            raise AuthenticationError(
+                f"Could not reach Qobuz login endpoint: "
+                f"{type(exc).__name__}.\n" + RESET
+            ) from None
+
+        if r.status_code == 401:
+            raise AuthenticationError("Invalid token credentials.\n" + RESET)
+        if r.status_code == 400:
+            raise InvalidAppIdError("Invalid app id.\n" + RESET)
+        if not r.ok:
+            # Don't call r.raise_for_status(): the resulting HTTPError's
+            # str() embeds request.url, which contains user_auth_token.
+            raise AuthenticationError(
+                f"Login failed: HTTP {r.status_code}.\n" + RESET
+            )
+
+        try:
+            usr_info = r.json()
+        except ValueError:
+            raise AuthenticationError(
+                "Unexpected non-JSON login response from Qobuz.\n" + RESET
+            ) from None
+
+        if not usr_info.get("user", {}).get("credential", {}).get("parameters"):
+            raise IneligibleError(
+                "Free accounts are not eligible to download tracks."
+            )
+
+        # Trust the user-supplied token rather than relying on the response
+        # to echo it back — the /user/login response shape is not contractual.
+        self.uat = user_auth_token
+        self.session.headers.update({"X-User-Auth-Token": self.uat})
+        self.label = _extract_label(usr_info)
+        logger.info(f"{GREEN}Membership: {self.label}")
 
     def api_call(self, epoint, **kwargs):
-        if epoint == "user/login":
-            params = {
-                "email": kwargs["email"],
-                "password": kwargs["pwd"],
-                "app_id": self.id,
-            }
-        elif epoint == "track/get":
+        if epoint == "track/get":
             params = {"track_id": kwargs["id"]}
         elif epoint == "album/get":
             params = {"album_id": kwargs["id"]}
@@ -105,31 +202,28 @@ class Client:
             }
         else:
             params = kwargs
-        r = self.session.get(self.base + epoint, params=params)
-        if epoint == "user/login":
-            if r.status_code == 401:
-                raise AuthenticationError("Invalid credentials.\n" + RESET)
-            elif r.status_code == 400:
-                raise InvalidAppIdError("Invalid app id.\n" + RESET)
-            else:
-                logger.info(f"{GREEN}Logged: OK")
-        elif (
+        r = self.session.get(self.base + epoint, params=params, timeout=_REQUEST_TIMEOUT)
+        if (
             epoint in ["track/getFileUrl", "favorite/getUserFavorites"]
             and r.status_code == 400
         ):
-            raise InvalidAppSecretError(f"Invalid app secret: {r.json()}.\n" + RESET)
+            # Embed only the server's `message` field; the full body is
+            # uncontracted and could echo request params (token-bearing).
+            try:
+                msg = r.json().get("message", "")
+            except ValueError:
+                msg = ""
+            raise InvalidAppSecretError(f"Invalid app secret ({msg}).\n" + RESET)
 
-        r.raise_for_status()
+        if not r.ok:
+            # Don't call r.raise_for_status(): some endpoints
+            # (favorite/getUserFavorites) embed user_auth_token in the query
+            # string, and HTTPError's str()/repr() echoes request.url verbatim.
+            # Raise a sanitized HTTPError that drops the URL.
+            raise requests.HTTPError(
+                f"HTTP {r.status_code} from {epoint}"
+            ) from None
         return r.json()
-
-    def auth(self, email, pwd):
-        usr_info = self.api_call("user/login", email=email, pwd=pwd)
-        if not usr_info["user"]["credential"]["parameters"]:
-            raise IneligibleError("Free accounts are not eligible to download tracks.")
-        self.uat = usr_info["user_auth_token"]
-        self.session.headers.update({"X-User-Auth-Token": self.uat})
-        self.label = usr_info["user"]["credential"]["parameters"]["short_label"]
-        logger.info(f"{GREEN}Membership: {self.label}")
 
     def multi_meta(self, epoint, key, id, type):
         total = 1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
 
 setup(
     name=pkg_name,
-    version="0.9.9.10",
+    version="0.9.10.0",
     author="Vitiko",
     author_email="vhnz98@gmail.com",
     description="The complete Lossless and Hi-Res music downloader for Qobuz",
@@ -28,19 +28,28 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/vitiko98/Qobuz-DL",
     install_requires=requirements,
+    extras_require={
+        "dev": ["pytest>=7", "responses>=0.24"],
+    },
     entry_points={
         "console_scripts": [
             "qobuz-dl = qobuz_dl:main",
             "qdl = qobuz_dl:main",
         ],
     },
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    # 3.8 went EOL Oct 2024; pytest 8.4+ and recent `responses` releases
+    # have already dropped it. Keep runtime/test floor in sync.
+    python_requires=">=3.9",
 )
 
 # rm -f dist/*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def bundle_snippet() -> str:
+    return (FIXTURES_DIR / "bundle.js.snippet").read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def tmp_config_dir(tmp_path, monkeypatch):
+    """Redirect ~/.config/qobuz-dl (or %APPDATA%/qobuz-dl) into a tmp_path."""
+    fake_home = tmp_path / "config-root"
+    fake_home.mkdir()
+    if os.name == "nt":
+        monkeypatch.setenv("APPDATA", str(fake_home))
+    else:
+        monkeypatch.setenv("HOME", str(fake_home))
+    return fake_home

--- a/tests/fixtures/bundle.js.snippet
+++ b/tests/fixtures/bundle.js.snippet
@@ -1,0 +1,22 @@
+// === fixture excerpt of https://play.qobuz.com/resources/8.1.0-b019/bundle.js ===
+// Captured 2026-04-26 for regression testing. Do not edit.
+
+// --- production app block ---
+production:{api:{appId:"798273057",appSecret:"05a4851e74ee47fda346f50cfdfc4f09"},braze:o(o({},u),{},{apiKey:"b464b6f4-ee64-4efe-91b5-5b43f8932bed"}),extra:l}};var d=window.__ENVIRONMENT__;t.default=c[d]||null;e.exports=t.default
+
+// --- genSignedRequest (new SHA-256 keyed scheme) ---
+{key:"genSignedRequest",value:function(e,t){var r=window.rng,n="";if(!t){var a=this._arguments,i=[];for(var o in a)Object.prototype.hasOwnProperty.call(a,o)&&i.push(o);i.sort();for(var s=0;s<i.length;s++){var l=i[s];n+="".concat(l).concat(a[l])}}return this._raw_sig="".concat(this._object_wanted).concat(this._method_wanted).concat(t?"":n).concat(e).concat(c.default.qobuzApi.appSecret),this._requestIdentifier="".concat(this._object_wanted).concat(this._method_wanted).concat(t?"":n).concat(e).concat(r.prototype.initialization()),(0,p.sha256)(this._raw_sig,this._requestIdentifier)}
+
+// --- localuser marker (storage key for the auth token) ---
+t.STORAGE_USER_KEY="localuser"
+
+// --- seed/timezone tokens for get_secrets() ---
+c.initialSeed("ZjY5YTc3MzQ2ODZjYjk0Mjc2MjkzNz",window.utimezone.london)
+c.initialSeed("ODA2MzMxYzNiMGI2NDFkYTkyM2I4OT",window.utimezone.abidjan)
+c.initialSeed("YWJiMjEzNjQ5NDVjMDU4MzMwOTY2N2",window.utimezone.berlin)
+name:"Africa/Abidjan",info:"BhZWQwMWQwNGE=OGEzYTliNTgwZj",extras:"gxNGYxOThhODg3OGU4ZjUzZGY3ZGI="
+name:"Europe/Dublin",info:"M0MTc2ZGFjMTM=MTliOTEzYzViOG",extras:"Y5NGMxMzgxYjYwNGRiMTZiNTBkZDc="
+name:"Europe/London",info:"hhNGI3YWMzODE=MGI0ZGVlYzBkZD",extras:"ExNGE0ZDljZGYyNjk2NDZmMjcwZTg="
+name:"Africa/Algiers",info:"hkZDg1MGRiYWI=YmVlZDZhNDMwOW",extras:"ZlNDhhMDhmNDlmZDI2MmJkMDUxOTg="
+name:"Europe/Paris",info:"ViZDk1NzM4NDQ=ZTdlNzc5MzViOW",extras:"QxNGVlNmE2YjFmNDY3OTcwMjg3ODc="
+name:"Europe/Berlin",info:"QxM2NhM2Q5M2E=YmFhMDRlOTU2OD",extras:"E4NDM4ZGIzNTVlMjZlNjM1M2Y0ZTc="

--- a/tests/fixtures/user_login_response_credential_label_only.json
+++ b/tests/fixtures/user_login_response_credential_label_only.json
@@ -1,0 +1,14 @@
+{
+  "user_auth_token": "FAKE-TOKEN-FOR-TESTS-DO-NOT-USE",
+  "user": {
+    "id": 3394846,
+    "credential": {
+      "id": 12345,
+      "label": "Hi-Fi",
+      "parameters": {
+        "lossy_streaming": true,
+        "lossless_streaming": true
+      }
+    }
+  }
+}

--- a/tests/fixtures/user_login_response_free.json
+++ b/tests/fixtures/user_login_response_free.json
@@ -1,0 +1,11 @@
+{
+  "user_auth_token": "FAKE-TOKEN-FOR-TESTS-DO-NOT-USE",
+  "user": {
+    "id": 3394846,
+    "credential": {
+      "id": 999,
+      "label": "Free",
+      "parameters": null
+    }
+  }
+}

--- a/tests/fixtures/user_login_response_no_short_label.json
+++ b/tests/fixtures/user_login_response_no_short_label.json
@@ -1,0 +1,15 @@
+{
+  "user_auth_token": "FAKE-TOKEN-FOR-TESTS-DO-NOT-USE",
+  "user": {
+    "id": 3394846,
+    "credential": {
+      "id": 12345,
+      "label": "Sublime+",
+      "parameters": {
+        "lossy_streaming": true,
+        "lossless_streaming": true,
+        "label": "Sublime+ Premier"
+      }
+    }
+  }
+}

--- a/tests/fixtures/user_login_response_studio.json
+++ b/tests/fixtures/user_login_response_studio.json
@@ -1,0 +1,31 @@
+{
+  "user_auth_token": "FAKE-TOKEN-FOR-TESTS-DO-NOT-USE",
+  "user": {
+    "id": 3394846,
+    "publicId": "redacted",
+    "email": "redacted@example.com",
+    "login": "redacted",
+    "language_code": "en",
+    "zone": "world",
+    "country_code": "US",
+    "credential": {
+      "id": 12345,
+      "label": "Studio",
+      "description": "Studio Premier",
+      "parameters": {
+        "lossy_streaming": true,
+        "lossless_streaming": true,
+        "hires_streaming": true,
+        "hires_purchases_streaming": true,
+        "mobile_streaming": true,
+        "offline_streaming": true,
+        "hfp_purchase": true,
+        "included_format_group_ids": [1, 2, 3, 4],
+        "color_scheme": {"logo": "white"},
+        "label": "Studio Premier",
+        "short_label": "Studio",
+        "source": "qobuz"
+      }
+    }
+  }
+}

--- a/tests/test_bundle_regex.py
+++ b/tests/test_bundle_regex.py
@@ -1,0 +1,25 @@
+"""Canary tests against a captured live `bundle.js` excerpt.
+
+If Qobuz changes their bundle format these tests fail loudly, instead of
+the change being detected only when a real user runs `qobuz-dl -r`.
+"""
+
+from qobuz_dl.bundle import _APP_ID_REGEX
+
+
+def test_app_id_regex_matches_fixture(bundle_snippet):
+    match = _APP_ID_REGEX.search(bundle_snippet)
+    assert match is not None, "_APP_ID_REGEX no longer matches the live bundle"
+    assert match.group("app_id") == "798273057"
+
+
+def test_localuser_marker_present_in_fixture(bundle_snippet):
+    """The Qobuz web player stores its auth blob under
+    `localStorage.localuser`. This test pins the storage key so the
+    token-capture instructions in the README/UX stay correct.
+    """
+    assert "localuser" in bundle_snippet, (
+        "The 'localuser' marker is missing from the bundle. "
+        "Qobuz may have renamed the localStorage key — update the "
+        "token-capture UX in `_reset_config` and the README."
+    )

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,0 +1,386 @@
+"""Tests for `qobuz_dl.cli.main` dispatch precedence.
+
+Dispatch table (top-down):
+  (a) --reset                       -> run reset
+  (b) no config file                -> run reset interactively
+  (c) user_id + user_auth_token     -> initialize_client_with_token
+  (d) email/password keys but no token -> exit(2) with migration message
+  (e) corrupt/unparseable config    -> exit(2) with --reset pointer
+  (f) no credentials at all         -> exit(2) with capture instructions
+"""
+
+import configparser
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qobuz_dl import cli
+
+
+def _write_config(path, **fields):
+    parser = configparser.ConfigParser()
+    parser["DEFAULT"] = {
+        "default_folder": "Qobuz Downloads",
+        "default_quality": "6",
+        "default_limit": "20",
+        "no_m3u": "false",
+        "albums_only": "false",
+        "no_fallback": "false",
+        "og_cover": "false",
+        "embed_art": "false",
+        "no_cover": "false",
+        "no_database": "false",
+        "app_id": "798273057",
+        "secrets": "secretA,secretB",
+        "smart_discography": "false",
+        "folder_format": "{artist} - {album}",
+        "track_format": "{tracknumber}. {tracktitle}",
+        **fields,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        parser.write(f)
+
+
+def _patch_cli_paths(monkeypatch, tmp_path):
+    config_dir = tmp_path / "qobuz-dl"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / "config.ini"
+    monkeypatch.setattr(cli, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(cli, "CONFIG_FILE", str(config_file))
+    monkeypatch.setattr(cli, "QOBUZ_DB", str(config_dir / "qobuz.db"))
+    return str(config_file)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_qobuzdl(monkeypatch):
+    """Replace QobuzDL so tests don't touch the filesystem or network."""
+    fake = MagicMock()
+    fake_class = MagicMock(return_value=fake)
+    monkeypatch.setattr(cli, "QobuzDL", fake_class)
+    monkeypatch.setattr(cli, "_handle_commands", MagicMock())
+    return fake
+
+
+def test_main_dispatches_to_token_auth_when_present(tmp_path, monkeypatch, _no_real_qobuzdl):
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    _write_config(
+        config_file,
+        user_id="3394846",
+        user_auth_token="real-token",
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+
+    cli.main()
+
+    _no_real_qobuzdl.initialize_client_with_token.assert_called_once()
+    args, _kwargs = _no_real_qobuzdl.initialize_client_with_token.call_args
+    assert args[0] == "3394846"
+    assert args[1] == "real-token"
+    assert args[2] == "798273057"
+
+
+def test_main_no_config_file_runs_reset(tmp_path, monkeypatch):
+    """Branch (b): no config file at all -> interactive reset."""
+    config_dir = tmp_path / "qobuz-dl"
+    config_file = config_dir / "config.ini"
+    monkeypatch.setattr(cli, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(cli, "CONFIG_FILE", str(config_file))
+    monkeypatch.setattr(cli, "QOBUZ_DB", str(config_dir / "qobuz.db"))
+    monkeypatch.setattr("sys.argv", ["qobuz-dl"])
+
+    reset_calls = []
+
+    def fake_reset(target):
+        reset_calls.append(target)
+        # Simulate an empty/uncreated config to terminate main early.
+        raise SystemExit(0)
+
+    monkeypatch.setattr(cli, "_reset_config", fake_reset)
+
+    with pytest.raises(SystemExit):
+        cli.main()
+    assert reset_calls == [str(config_file)]
+
+
+def test_main_legacy_email_password_exits_with_migration_message(
+    tmp_path, monkeypatch, capsys
+):
+    """Branch (d): old config with email/password but no token -> exit(2)."""
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    _write_config(
+        config_file,
+        email="user@example.com",
+        password="md5hash",
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "no longer supported" in err.lower() or "deprecated" in err.lower()
+    assert "--reset" in err or "user_id" in err
+
+
+def test_main_corrupt_config_exits_with_pointer_to_reset(
+    tmp_path, monkeypatch, capsys
+):
+    """Branch (e): config exists but configparser raises -> exit(2)."""
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    # Write an unparseable config file.
+    with open(config_file, "w", encoding="utf-8") as f:
+        f.write("[[[ not a valid ini file\n")
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "--reset" in err or "corrupt" in err.lower()
+
+
+def test_main_semantically_corrupt_config_exits_cleanly(
+    tmp_path, monkeypatch, capsys
+):
+    """Branch (e), part 2: config parses fine but a boolean value is junk
+    (`no_cover = maybe`). configparser.getboolean raises ValueError.
+    The CLI must exit(2) cleanly, not traceback.
+    """
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    _write_config(
+        config_file,
+        user_id="3394846",
+        user_auth_token="t",
+        no_cover="maybe",  # not a valid bool
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "--reset" in err or "corrupt" in err.lower()
+
+
+def test_main_no_credentials_in_otherwise_valid_config_exits(
+    tmp_path, monkeypatch, capsys
+):
+    """Branch (f): config parses but has no creds at all -> exit(2)."""
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    _write_config(config_file)  # no user_id/email/password
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+
+    err = capsys.readouterr().err
+    assert "--reset" in err or "credentials" in err.lower()
+
+
+def test_main_quality_fallback_wiring(tmp_path, monkeypatch, _no_real_qobuzdl):
+    """Pin the no_fallback boolean wiring: setting `no_fallback=true` in
+    the config (or `--no-fallback` on the CLI) MUST disable quality
+    fallback. Regression test for cli.py:268 — the original
+    `not arguments.no_fallback or not no_fallback` was
+    `(not A) or (not B)` and only honored the flag when both sources
+    agreed.
+    """
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+
+    # Case 1: config-only no_fallback=true, no CLI flag → fallback disabled.
+    _write_config(
+        config_file,
+        user_id="3394846",
+        user_auth_token="real-token",
+        no_fallback="true",
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+    cli.main()
+    _, kwargs = cli.QobuzDL.call_args
+    assert kwargs["quality_fallback"] is False, (
+        "config no_fallback=true should disable quality_fallback "
+        "(regression — boolean wiring bug)"
+    )
+
+    # Case 2: config no_fallback=false, CLI --no-fallback → fallback disabled.
+    _write_config(
+        config_file,
+        user_id="3394846",
+        user_auth_token="real-token",
+        no_fallback="false",
+    )
+    cli.QobuzDL.reset_mock()
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun", "--no-fallback"])
+    cli.main()
+    _, kwargs = cli.QobuzDL.call_args
+    assert kwargs["quality_fallback"] is False
+
+    # Case 3: both false → fallback enabled.
+    _write_config(
+        config_file,
+        user_id="3394846",
+        user_auth_token="real-token",
+        no_fallback="false",
+    )
+    cli.QobuzDL.reset_mock()
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+    cli.main()
+    _, kwargs = cli.QobuzDL.call_args
+    assert kwargs["quality_fallback"] is True
+
+
+def test_main_corrupt_config_does_not_echo_token(tmp_path, monkeypatch, capsys):
+    """Pin the contract: when the config is malformed in a way that
+    triggers configparser.ParsingError, the error message printed to
+    stderr MUST NOT include the offending source line (which can be the
+    `user_auth_token = ...` line itself).
+    """
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    SECRET = "ABC-VERY-SECRET-TOKEN-IN-BAD-LINE"
+    # Hand-rolled malformed INI: a continuation line with no preceding key.
+    with open(config_file, "w", encoding="utf-8") as f:
+        f.write(
+            "[DEFAULT]\n"
+            "  bogus continuation line\n"
+            f"user_auth_token = {SECRET}\n"
+        )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+
+    err = capsys.readouterr().err
+    assert SECRET not in err, (
+        "stderr leaked the user_auth_token via raw configparser error message"
+    )
+    # Should still be informative.
+    assert "--reset" in err
+
+
+def test_main_unicode_decode_error_in_config(tmp_path, monkeypatch, capsys):
+    """Non-UTF-8 bytes in the config file (e.g. cp1252-encoded by a
+    Windows editor) must surface as a clean exit(2), not a traceback.
+    Cross-platform test: writes raw bytes, doesn't depend on filesystem
+    encoding semantics.
+    """
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    # 0xff is invalid as a UTF-8 leading byte.
+    with open(config_file, "wb") as f:
+        f.write(b"[DEFAULT]\nuser_id = \xff\xfe\n")
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "--reset" in err or "corrupt" in err.lower()
+
+
+def test_main_stale_token_exits_cleanly_not_traceback(
+    tmp_path, monkeypatch, capsys, _no_real_qobuzdl
+):
+    """A revoked / stale `user_auth_token` causes Client.from_token to
+    raise AuthenticationError. main() must exit(2) with the message,
+    not propagate a traceback.
+    """
+    from qobuz_dl.exceptions import AuthenticationError
+
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    _write_config(
+        config_file,
+        user_id="3394846",
+        user_auth_token="stale-token",
+    )
+    _no_real_qobuzdl.initialize_client_with_token.side_effect = AuthenticationError(
+        "Invalid token credentials.\nReset your credentials with 'qobuz-dl -r'"
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "fun"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "Invalid token credentials" in err
+    assert "qobuz-dl -r" in err
+
+
+def test_main_show_config_works_when_config_corrupt(tmp_path, monkeypatch, capsys):
+    """`--show-config` must work even when the strict config-load would
+    fail — that's the case where users most need to inspect the file.
+    Regression for the M2 reordering.
+    """
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    # Malformed INI but contains a (redactable) user_auth_token.
+    with open(config_file, "w", encoding="utf-8") as f:
+        f.write(
+            "[DEFAULT]\n"
+            "  bad continuation line\n"
+            "user_auth_token = SECRET-IN-CORRUPT-CONFIG\n"
+        )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "--show-config"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    # show_config exits with sys.exit() → code is None.
+    assert exc.value.code in (None, 0)
+
+    out = capsys.readouterr().out
+    # The fallback regex in _redact_config_text handles malformed INI.
+    assert "SECRET-IN-CORRUPT-CONFIG" not in out
+    assert "***REDACTED***" in out
+
+
+def test_main_purge_works_when_config_corrupt(tmp_path, monkeypatch, capsys):
+    """`--purge` must not be gated behind a successful config-load."""
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    # Truly broken config.
+    with open(config_file, "w", encoding="utf-8") as f:
+        f.write("[[[ totally broken\n")
+    # Create a fake DB file so we can prove --purge removed it.
+    db_file = tmp_path / "qobuz-dl" / "qobuz.db"
+    db_file.write_text("fake")
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "--purge"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+    assert not db_file.exists()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["qobuz-dl", "dl", "https://example/album/x"],
+        ["qobuz-dl", "fun"],
+        ["qobuz-dl", "lucky", "some", "query"],
+    ],
+)
+def test_main_download_subcommand_with_no_secret_warns_and_exits(
+    tmp_path, monkeypatch, capsys, _no_real_qobuzdl, argv
+):
+    """If login succeeds but cfg_setup couldn't validate any secret
+    (i.e. client.sec is None), every download-capable subcommand must
+    exit cleanly with code 3 + README pointer rather than tracebacking
+    from InvalidAppSecretError mid-download.
+    """
+    config_file = _patch_cli_paths(monkeypatch, tmp_path)
+    _write_config(
+        config_file,
+        user_id="3394846",
+        user_auth_token="real-token",
+    )
+    _no_real_qobuzdl.client = MagicMock()
+    _no_real_qobuzdl.client.sec = None
+    monkeypatch.setattr("sys.argv", argv)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 3
+
+    err = capsys.readouterr().err
+    assert "downloads currently fail" in err.lower() or "signing" in err.lower()
+    assert "readme" in err.lower() or "see " in err.lower()

--- a/tests/test_cli_reset.py
+++ b/tests/test_cli_reset.py
@@ -1,0 +1,94 @@
+"""Tests for `qobuz_dl.cli._reset_config`.
+
+The reset flow now prompts only for `user_id` + `user_auth_token`
+(email/password is gone). It must use the atomic config-write helper
+and never persist a `password` or `email` key.
+"""
+
+import configparser
+from collections import OrderedDict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qobuz_dl import cli
+
+
+@pytest.fixture
+def fake_bundle(monkeypatch):
+    """Stub `qobuz_dl.cli.Bundle()` so reset doesn't hit play.qobuz.com."""
+    bundle = MagicMock()
+    bundle.get_app_id.return_value = "798273057"
+    bundle.get_secrets.return_value = OrderedDict([("london", "secretA"), ("paris", "secretB")])
+    monkeypatch.setattr(cli, "Bundle", lambda: bundle)
+    return bundle
+
+
+def test_reset_writes_token_keys_only(tmp_path, fake_bundle):
+    target = tmp_path / "config.ini"
+    # user_id + folder + quality go through input(); user_auth_token uses
+    # getpass so the token is never echoed to terminal scrollback.
+    plain_inputs = iter(["3394846", "", ""])
+    with patch("builtins.input", lambda *_a, **_kw: next(plain_inputs)), \
+         patch("qobuz_dl.cli.getpass.getpass", return_value="real-token-xyz"):
+        cli._reset_config(str(target))
+
+    parser = configparser.ConfigParser()
+    parser.read(str(target))
+
+    assert parser["DEFAULT"]["user_id"] == "3394846"
+    assert parser["DEFAULT"]["user_auth_token"] == "real-token-xyz"
+    assert parser["DEFAULT"]["app_id"] == "798273057"
+    assert "secretA" in parser["DEFAULT"]["secrets"]
+
+    # Email/password must NOT be written by the new reset flow.
+    assert "email" not in parser["DEFAULT"]
+    assert "password" not in parser["DEFAULT"]
+
+
+def test_reset_uses_getpass_for_token(tmp_path, fake_bundle):
+    """Pin the contract: user_auth_token must NOT be collected via plain
+    input() (which echoes to terminal scrollback / tmux / screen-share).
+    Regression guard for the M5 fix.
+    """
+    target = tmp_path / "config.ini"
+    plain_inputs = iter(["3394846", "", ""])
+    with patch("builtins.input", lambda *_a, **_kw: next(plain_inputs)) as input_mock, \
+         patch("qobuz_dl.cli.getpass.getpass") as getpass_mock:
+        getpass_mock.return_value = "secret-token"
+        cli._reset_config(str(target))
+
+    # getpass.getpass MUST have been the prompt that received the token.
+    getpass_mock.assert_called_once()
+    parser = configparser.ConfigParser()
+    parser.read(str(target))
+    assert parser["DEFAULT"]["user_auth_token"] == "secret-token"
+
+
+def test_reset_uses_atomic_writer(tmp_path, fake_bundle, monkeypatch):
+    """Pin the contract: `_reset_config` must funnel through
+    `atomic_write_config`, never `open(..., 'w')` directly. A regression
+    here would risk partial writes to the credentials store.
+    """
+    target = tmp_path / "config.ini"
+    seen = {}
+
+    def fake_atomic(path, parser):
+        seen["path"] = path
+        seen["user_id"] = parser["DEFAULT"]["user_id"]
+        seen["user_auth_token"] = parser["DEFAULT"]["user_auth_token"]
+        # Don't actually write — proves the test holds even when the writer is mocked.
+
+    monkeypatch.setattr(cli, "atomic_write_config", fake_atomic)
+    plain_inputs = iter(["3394846", "", ""])
+    with patch("builtins.input", lambda *_a, **_kw: next(plain_inputs)), \
+         patch("qobuz_dl.cli.getpass.getpass", return_value="t"):
+        cli._reset_config(str(target))
+
+    assert seen == {
+        "path": str(target),
+        "user_id": "3394846",
+        "user_auth_token": "t",
+    }
+    # Confirm: nothing was written through any other path.
+    assert not target.exists()

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,0 +1,149 @@
+"""Tests for the atomic config-write helper.
+
+Token-bearing config files are sensitive — partial writes would corrupt
+the only credentials store. These tests pin the temp-then-replace idiom
+plus 0600 permissions on POSIX.
+"""
+
+import configparser
+import io
+import os
+import stat
+
+import pytest
+
+from qobuz_dl._config_io import atomic_write_config
+
+
+def _build_parser(**defaults):
+    cp = configparser.ConfigParser()
+    cp["DEFAULT"] = defaults
+    return cp
+
+
+def _list_tempfiles(directory):
+    return [p for p in directory.iterdir() if p.name.startswith(".config-")]
+
+
+def test_atomic_write_creates_file_and_writes_keys(tmp_path):
+    target = tmp_path / "config.ini"
+    parser = _build_parser(user_id="3394846", user_auth_token="t-xyz")
+
+    atomic_write_config(str(target), parser)
+
+    assert target.is_file()
+    content = target.read_text(encoding="utf-8")
+    assert "user_id = 3394846" in content
+    assert "user_auth_token = t-xyz" in content
+
+
+def test_atomic_write_preserves_existing_on_failure(tmp_path, monkeypatch):
+    """If os.replace raises mid-flight, the original config must remain
+    untouched and no orphan temp files should clutter the target dir.
+    """
+    target = tmp_path / "config.ini"
+    target.write_text("[DEFAULT]\nuser_id = OLD_VALUE\n", encoding="utf-8")
+    original = target.read_text(encoding="utf-8")
+
+    parser = _build_parser(user_id="NEW_VALUE")
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("simulated rename failure")
+
+    monkeypatch.setattr(os, "replace", _boom)
+
+    with pytest.raises(OSError):
+        atomic_write_config(str(target), parser)
+
+    # Original is intact.
+    assert target.read_text(encoding="utf-8") == original
+
+    # No orphan temp file left behind in the directory.
+    leftovers = [p for p in tmp_path.iterdir() if p != target]
+    assert leftovers == [], f"orphan temp file(s): {leftovers}"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics")
+def test_atomic_write_sets_0600_on_posix(tmp_path):
+    target = tmp_path / "config.ini"
+    parser = _build_parser(user_id="x", user_auth_token="y")
+
+    atomic_write_config(str(target), parser)
+
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+
+def test_atomic_write_cleans_temp_when_parser_write_raises(tmp_path, monkeypatch):
+    """If `parser.write(tmp)` blows up before we ever reach os.replace,
+    the partially-written temp file must be unlinked and the original
+    target file preserved.
+    """
+    target = tmp_path / "config.ini"
+    target.write_text("[DEFAULT]\nuser_id = OLD\n", encoding="utf-8")
+
+    class BoomParser:
+        def write(self, fp):
+            fp.write("partial...")  # write something to the temp file
+            raise RuntimeError("simulated parser failure")
+
+    with pytest.raises(RuntimeError, match="simulated parser failure"):
+        atomic_write_config(str(target), BoomParser())
+
+    assert target.read_text(encoding="utf-8") == "[DEFAULT]\nuser_id = OLD\n"
+    assert _list_tempfiles(tmp_path) == []
+
+
+def test_atomic_write_cleans_temp_when_fsync_raises(tmp_path, monkeypatch):
+    """If `os.fsync(tmp.fileno())` raises (rare but possible on some
+    filesystems / closed fds) the temp file must be unlinked and the
+    target preserved.
+    """
+    target = tmp_path / "config.ini"
+    target.write_text("[DEFAULT]\nuser_id = OLD\n", encoding="utf-8")
+
+    real_fsync = os.fsync
+    calls = {"n": 0}
+
+    def selective_fsync(fd):
+        calls["n"] += 1
+        # First call is the temp-file fsync (the one we're targeting).
+        if calls["n"] == 1:
+            raise OSError("simulated fsync failure")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", selective_fsync)
+
+    parser = _build_parser(user_id="NEW", user_auth_token="t")
+    with pytest.raises(OSError, match="simulated fsync failure"):
+        atomic_write_config(str(target), parser)
+
+    assert target.read_text(encoding="utf-8") == "[DEFAULT]\nuser_id = OLD\n"
+    assert _list_tempfiles(tmp_path) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX chmod semantics")
+def test_atomic_write_chmod_failure_after_replace_does_not_corrupt(
+    tmp_path, monkeypatch
+):
+    """If chmod fails after a successful os.replace, the new content is
+    already in place. Pin the contract: the failure surfaces but the
+    target file holds the new content (NOT the old one).
+
+    Rationale: at this point we've already committed; the file mode is
+    a hardening concern, not a correctness one.
+    """
+    target = tmp_path / "config.ini"
+    target.write_text("[DEFAULT]\nuser_id = OLD\n", encoding="utf-8")
+
+    def boom_chmod(_path, _mode):
+        raise OSError("simulated chmod failure")
+
+    monkeypatch.setattr(os, "chmod", boom_chmod)
+
+    parser = _build_parser(user_id="NEW", user_auth_token="t")
+    with pytest.raises(OSError, match="simulated chmod failure"):
+        atomic_write_config(str(target), parser)
+
+    # Replace already happened; the new content is durable.
+    assert "user_id = NEW" in target.read_text(encoding="utf-8")

--- a/tests/test_qopy.py
+++ b/tests/test_qopy.py
@@ -1,0 +1,425 @@
+"""Tests for `qobuz_dl.qopy.Client`.
+
+The old `Client(email, pwd, app_id, secrets)` constructor authenticated
+inside __init__ via Qobuz's email/password flow, which Qobuz disabled
+server-side in April 2026. The new constructor takes only (app_id, secrets)
+and auth happens via `Client.from_token(...)`.
+"""
+
+import json
+import logging
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import responses
+
+from qobuz_dl.exceptions import (
+    AuthenticationError,
+    IneligibleError,
+    InvalidAppIdError,
+)
+from qobuz_dl.qopy import Client
+
+FIXTURES = Path(__file__).parent / "fixtures"
+LOGIN_URL = "https://www.qobuz.com/api.json/0.2/user/login"
+GETFILEURL_URL = "https://www.qobuz.com/api.json/0.2/track/getFileUrl"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# constructor surface
+# ---------------------------------------------------------------------------
+
+
+def test_old_init_signature_removed():
+    """The legacy `Client(email, pwd, app_id, secrets)` signature must be
+    gone. Calling it with that arity should raise TypeError so old callers
+    fail loudly instead of silently constructing a broken client.
+    """
+    with pytest.raises(TypeError):
+        Client("a@b.com", "pwd", "1", [])
+
+
+# ---------------------------------------------------------------------------
+# Client.from_token
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_from_token_happy_path():
+    """A successful token login sets uat, the X-User-Auth-Token header,
+    and a non-empty membership label.
+    """
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json=_load_fixture("user_login_response_studio.json"),
+        status=200,
+    )
+    # cfg_setup will probe track/getFileUrl. Make those probes fail so we
+    # don't conflate the happy-path login test with cfg_setup behaviour
+    # (covered separately).
+    responses.add(
+        responses.GET,
+        GETFILEURL_URL,
+        json={"code": 400, "message": "Invalid Request Signature parameter"},
+        status=400,
+    )
+
+    client = Client.from_token(
+        user_id="3394846",
+        user_auth_token="real-token-xyz",
+        app_id="798273057",
+        secrets=["secret1"],
+    )
+
+    assert client.uat == "real-token-xyz"
+    assert client.session.headers.get("X-User-Auth-Token") == "real-token-xyz"
+    assert client.label  # non-empty
+    assert client.label != "Unknown"
+
+
+@responses.activate
+def test_from_token_sends_correct_query_params():
+    """The login request must carry user_id, user_auth_token, and app_id
+    as GET query params (not headers, not body).
+    """
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json=_load_fixture("user_login_response_studio.json"),
+        status=200,
+    )
+    responses.add(responses.GET, GETFILEURL_URL, json={}, status=400)
+
+    Client.from_token(
+        user_id="3394846",
+        user_auth_token="real-token-xyz",
+        app_id="798273057",
+        secrets=["secret1"],
+    )
+
+    login_call = next(c for c in responses.calls if "user/login" in c.request.url)
+    qs = parse_qs(urlparse(login_call.request.url).query)
+    assert qs["user_id"] == ["3394846"]
+    assert qs["user_auth_token"] == ["real-token-xyz"]
+    assert qs["app_id"] == ["798273057"]
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "fixture,expected_label_contains",
+    [
+        ("user_login_response_studio.json", "Studio"),  # has short_label
+        ("user_login_response_no_short_label.json", "Sublime"),  # parameters.label only
+        ("user_login_response_credential_label_only.json", "Hi-Fi"),  # credential.label only
+    ],
+)
+def test_from_token_label_extraction_tolerant(fixture, expected_label_contains):
+    """Label is read from credential.parameters.short_label if present,
+    else credential.parameters.label, else credential.label. None of
+    these should raise KeyError if the response shape drifts.
+    """
+    responses.add(responses.GET, LOGIN_URL, json=_load_fixture(fixture), status=200)
+    responses.add(responses.GET, GETFILEURL_URL, json={}, status=400)
+
+    client = Client.from_token(
+        user_id="3394846",
+        user_auth_token="t",
+        app_id="798273057",
+        secrets=["s"],
+    )
+    assert expected_label_contains in client.label
+
+
+@responses.activate
+def test_from_token_label_extraction_falls_back_to_unknown():
+    """If the response carries no recognizable label field, _extract_label
+    must return "Unknown" instead of raising KeyError. This protects
+    against minor schema drift on Qobuz's side.
+    """
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json={
+            "user_auth_token": "FAKE",
+            "user": {
+                "id": 1,
+                "credential": {
+                    "id": 1,
+                    # no `label` here, no `parameters` either ...
+                    "parameters": {"lossy_streaming": True},
+                },
+            },
+        },
+        status=200,
+    )
+    responses.add(responses.GET, GETFILEURL_URL, json={}, status=400)
+
+    client = Client.from_token(
+        user_id="1",
+        user_auth_token="t",
+        app_id="798273057",
+        secrets=["s"],
+    )
+    assert client.label == "Unknown"
+
+
+@responses.activate
+def test_from_token_401_raises_auth_error():
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json={"code": 401, "message": "User authentication is required."},
+        status=401,
+    )
+    with pytest.raises(AuthenticationError):
+        Client.from_token(
+            user_id="3394846",
+            user_auth_token="bad-token",
+            app_id="798273057",
+            secrets=["s"],
+        )
+
+
+@responses.activate
+def test_from_token_400_raises_invalid_app_id():
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json={"code": 400, "message": "Invalid app id."},
+        status=400,
+    )
+    with pytest.raises(InvalidAppIdError):
+        Client.from_token(
+            user_id="3394846",
+            user_auth_token="t",
+            app_id="badappid",
+            secrets=["s"],
+        )
+
+
+@responses.activate
+def test_from_token_free_account_raises_ineligible():
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json=_load_fixture("user_login_response_free.json"),
+        status=200,
+    )
+    with pytest.raises(IneligibleError):
+        Client.from_token(
+            user_id="3394846",
+            user_auth_token="t",
+            app_id="798273057",
+            secrets=["s"],
+        )
+
+
+@responses.activate
+def test_from_token_does_not_leak_token_on_5xx(caplog):
+    """A non-401/400 server error must NOT propagate the request URL
+    (which contains user_auth_token) into the exception text or logs.
+    """
+    SECRET = "TOTALLY-SECRET-TOKEN-DO-NOT-LEAK"
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json={"code": 503, "message": "Service Unavailable"},
+        status=503,
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(AuthenticationError) as exc_info:
+            Client.from_token(
+                user_id="3394846",
+                user_auth_token=SECRET,
+                app_id="798273057",
+                secrets=["s"],
+            )
+
+    assert SECRET not in str(exc_info.value)
+    assert SECRET not in repr(exc_info.value)
+    assert SECRET not in caplog.text
+
+
+@responses.activate
+def test_from_token_does_not_leak_token_on_connection_error(caplog):
+    """A network error must NOT surface the URL or token via the
+    propagated exception message.
+    """
+    SECRET = "TOTALLY-SECRET-TOKEN-DO-NOT-LEAK"
+    # Deliberately don't register a mock; responses raises ConnectionError.
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(AuthenticationError) as exc_info:
+            Client.from_token(
+                user_id="3394846",
+                user_auth_token=SECRET,
+                app_id="798273057",
+                secrets=["s"],
+            )
+
+    assert SECRET not in str(exc_info.value)
+    assert SECRET not in repr(exc_info.value)
+    assert SECRET not in caplog.text
+
+
+@responses.activate
+def test_from_token_handles_non_json_login_response():
+    """A 200 with an HTML body (proxy interstitial, captcha) must surface
+    as AuthenticationError, not a JSONDecodeError traceback.
+    """
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        body="<html>Service unavailable</html>",
+        status=200,
+        content_type="text/html",
+    )
+    with pytest.raises(AuthenticationError):
+        Client.from_token(
+            user_id="3394846",
+            user_auth_token="t",
+            app_id="798273057",
+            secrets=["s"],
+        )
+
+
+@responses.activate
+def test_from_token_succeeds_when_cfg_setup_fails(caplog):
+    """If cfg_setup() can't validate any secret (the 2026 SHA-256 signing
+    migration breaks the MD5-signed track/getFileUrl probe), login itself
+    must still succeed and the client must still be usable for
+    metadata/search. `client.sec` stays None and a clear warning is
+    emitted so users know downloads will fail.
+    """
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json=_load_fixture("user_login_response_studio.json"),
+        status=200,
+    )
+    # Every secret probe returns 400.
+    responses.add(
+        responses.GET,
+        GETFILEURL_URL,
+        json={"code": 400, "message": "Invalid Request Signature parameter"},
+        status=400,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        client = Client.from_token(
+            user_id="3394846",
+            user_auth_token="t",
+            app_id="798273057",
+            secrets=["secretA", "secretB", "secretC"],
+        )
+
+    assert client.uat == "t"
+    assert client.sec is None
+    assert any(
+        "downloads will fail" in record.message.lower()
+        or "signing" in record.message.lower()
+        for record in caplog.records
+    ), f"expected a download-broken warning in logs; got: {[r.message for r in caplog.records]}"
+
+
+@responses.activate
+def test_api_call_does_not_leak_token_on_http_error(caplog):
+    """`api_call('favorite/getUserFavorites', ...)` includes user_auth_token
+    in the GET query string. Any non-2xx (other than 400) used to call
+    `r.raise_for_status()`, whose HTTPError str/repr embeds request.url
+    verbatim — leaking the token to logs and tracebacks. Pin the contract:
+    the sanitized HTTPError must not echo the URL.
+    """
+    import requests
+    from qobuz_dl.qopy import Client
+
+    SECRET_UAT = "API-CALL-LEAK-CANARY-TOKEN"
+    FAVORITES_URL = "https://www.qobuz.com/api.json/0.2/favorite/getUserFavorites"
+
+    # Login OK to populate self.uat = SECRET_UAT.
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json=_load_fixture("user_login_response_studio.json"),
+        status=200,
+    )
+    # cfg_setup probes always fail (degraded mode) — keeps the test
+    # focused on api_call, not cfg_setup.
+    responses.add(
+        responses.GET,
+        GETFILEURL_URL,
+        json={"code": 400, "message": "fail"},
+        status=400,
+    )
+    # favorite/getUserFavorites returns a 503.
+    responses.add(
+        responses.GET,
+        FAVORITES_URL,
+        json={"code": 503, "message": "Service Unavailable"},
+        status=503,
+    )
+
+    client = Client.from_token(
+        user_id="3394846",
+        user_auth_token=SECRET_UAT,
+        app_id="798273057",
+        secrets=["s"],
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(requests.HTTPError) as exc_info:
+            # Call api_call directly with the signature secret —
+            # mirrors what download paths do once the new SHA-256 signing
+            # is reimplemented. user_auth_token still ends up in the
+            # query string regardless of `sec` value.
+            client.api_call(
+                "favorite/getUserFavorites",
+                type="albums",
+                offset=0,
+                limit=10,
+                sec="fake-secret",
+            )
+
+    assert SECRET_UAT not in str(exc_info.value)
+    assert SECRET_UAT not in repr(exc_info.value)
+    assert SECRET_UAT not in caplog.text
+    # Belt-and-braces: also no leaked URL via the chained context.
+    assert SECRET_UAT not in repr(exc_info.value.__context__)
+
+
+@responses.activate
+def test_from_token_succeeds_when_cfg_setup_hits_transport_error(caplog):
+    """cfg_setup probes are HTTP calls — if one of them raises a transient
+    ConnectionError (or 5xx) the codex-flagged downgrade must catch
+    requests.RequestException, not just InvalidAppSecretError. Login
+    itself already succeeded; the secret list just couldn't be probed.
+    """
+    responses.add(
+        responses.GET,
+        LOGIN_URL,
+        json=_load_fixture("user_login_response_studio.json"),
+        status=200,
+    )
+    # No mock for getFileUrl → responses raises ConnectionError.
+
+    with caplog.at_level(logging.WARNING):
+        client = Client.from_token(
+            user_id="3394846",
+            user_auth_token="t",
+            app_id="798273057",
+            secrets=["secretA"],
+        )
+
+    assert client.uat == "t"
+    assert client.sec is None  # cfg_setup couldn't validate any secret
+    assert any(
+        "downloads will fail" in r.message.lower()
+        for r in caplog.records
+    )

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -1,0 +1,185 @@
+"""Tests for `--show-config` redaction.
+
+`config.ini` is now stored at 0600, but users still copy/paste its
+contents into bug reports, screenshots, and logs. Default `--show-config`
+output redacts every secret-bearing key (`user_auth_token`, `secrets`,
+legacy `password`). `--show-secrets` opt-in reveals the raw values.
+
+`app_id` is NOT redacted: it's a public constant embedded in
+`bundle.js` and visible to anyone who opens DevTools.
+"""
+
+import configparser
+from unittest.mock import patch
+
+import pytest
+
+from qobuz_dl import cli
+
+
+def _write_config(path, **fields):
+    parser = configparser.ConfigParser()
+    parser["DEFAULT"] = {
+        "default_folder": "Qobuz Downloads",
+        "default_quality": "6",
+        "default_limit": "20",
+        "no_m3u": "false",
+        "albums_only": "false",
+        "no_fallback": "false",
+        "og_cover": "false",
+        "embed_art": "false",
+        "no_cover": "false",
+        "no_database": "false",
+        "app_id": "798273057",
+        "secrets": "secretA,secretB",
+        "smart_discography": "false",
+        "folder_format": "{artist} - {album}",
+        "track_format": "{tracknumber}. {tracktitle}",
+        **fields,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        parser.write(f)
+
+
+def _setup(monkeypatch, tmp_path, **config_fields):
+    config_dir = tmp_path / "qobuz-dl"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / "config.ini"
+    monkeypatch.setattr(cli, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(cli, "CONFIG_FILE", str(config_file))
+    monkeypatch.setattr(cli, "QOBUZ_DB", str(config_dir / "qobuz.db"))
+    _write_config(str(config_file), **config_fields)
+    return str(config_file)
+
+
+def test_show_config_redacts_user_auth_token_and_secrets_by_default(
+    tmp_path, monkeypatch, capsys
+):
+    _setup(
+        monkeypatch,
+        tmp_path,
+        user_id="3394846",
+        user_auth_token="ABC-VERY-SECRET-TOKEN-123",
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "--show-config"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+    out = capsys.readouterr().out
+
+    assert "ABC-VERY-SECRET-TOKEN-123" not in out
+    assert "secretA" not in out
+    assert "secretB" not in out
+    assert "***REDACTED***" in out
+    # app_id should NOT be redacted (public constant in bundle.js)
+    assert "798273057" in out
+
+
+def test_show_config_redacts_legacy_password_if_present(tmp_path, monkeypatch, capsys):
+    _setup(
+        monkeypatch,
+        tmp_path,
+        user_id="3394846",
+        user_auth_token="t",
+        email="user@example.com",
+        password="0123456789abcdef0123456789abcdef",  # md5-shaped
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "--show-config"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+    out = capsys.readouterr().out
+
+    assert "0123456789abcdef0123456789abcdef" not in out
+    # email is not a secret per se but is PII; we don't require redaction
+    # of it here. Re-check if/when we make a stronger claim.
+
+
+def test_show_config_redacts_multiline_continuation_values(
+    tmp_path, monkeypatch, capsys
+):
+    """`configparser` allows values to span multiple lines via leading
+    whitespace continuation. A regex-only redactor would only cover the
+    first line; the round-trip approach must replace the entire value.
+    """
+    config_dir = tmp_path / "qobuz-dl"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / "config.ini"
+    monkeypatch.setattr(cli, "CONFIG_PATH", str(config_dir))
+    monkeypatch.setattr(cli, "CONFIG_FILE", str(config_file))
+    monkeypatch.setattr(cli, "QOBUZ_DB", str(config_dir / "qobuz.db"))
+
+    # Hand-rolled INI with a continuation-line user_auth_token.
+    config_file.write_text(
+        "[DEFAULT]\n"
+        "user_id = 3394846\n"
+        "user_auth_token = LINE1-PART-OF-SECRET\n"
+        "    LINE2-CONTINUATION-OF-SECRET\n"
+        "default_folder = Qobuz Downloads\n"
+        "default_quality = 6\n"
+        "default_limit = 20\n"
+        "no_m3u = false\n"
+        "albums_only = false\n"
+        "no_fallback = false\n"
+        "og_cover = false\n"
+        "embed_art = false\n"
+        "no_cover = false\n"
+        "no_database = false\n"
+        "app_id = 798273057\n"
+        "secrets = secretA,secretB\n"
+        "smart_discography = false\n"
+        "folder_format = {artist} - {album}\n"
+        "track_format = {tracknumber}. {tracktitle}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "--show-config"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+    out = capsys.readouterr().out
+
+    assert "LINE1-PART-OF-SECRET" not in out
+    assert "LINE2-CONTINUATION-OF-SECRET" not in out
+    assert "***REDACTED***" in out
+
+
+def test_show_config_redacts_does_not_overmatch_benign_text(
+    tmp_path, monkeypatch, capsys
+):
+    """A benign value containing the literal word 'password' (e.g. a
+    folder name) must NOT be redacted — only values of keys named
+    user_auth_token / secrets / password.
+    """
+    _setup(
+        monkeypatch,
+        tmp_path,
+        user_id="3394846",
+        user_auth_token="t",
+        default_folder="Password Album Greatest Hits",
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "--show-config"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+    out = capsys.readouterr().out
+
+    assert "Password Album Greatest Hits" in out
+
+
+def test_show_secrets_flag_reveals_all(tmp_path, monkeypatch, capsys):
+    _setup(
+        monkeypatch,
+        tmp_path,
+        user_id="3394846",
+        user_auth_token="ABC-VERY-SECRET-TOKEN-123",
+    )
+    monkeypatch.setattr("sys.argv", ["qobuz-dl", "--show-config", "--show-secrets"])
+
+    with pytest.raises(SystemExit):
+        cli.main()
+    out = capsys.readouterr().out
+
+    assert "ABC-VERY-SECRET-TOKEN-123" in out
+    assert "secretA" in out
+    assert "secretB" in out
+    assert "***REDACTED***" not in out


### PR DESCRIPTION
## Why

Qobuz disabled email/password login server-side in April 2026. `qobuz-dl` no longer authenticates.

## What

Replace email/password with **token-based login**. User pastes `user_id` + `user_auth_token` from a logged-in browser session (one-liner in the DevTools console) and the CLI persists them at `~/.config/qobuz-dl/config.ini` (mode `0600` on POSIX).

- `Client.from_token(...)` classmethod is the new auth entry point; `Client(email, pwd, ...)` raises `TypeError`.
- Atomic config writer; `getpass` for the token prompt.
- `--show-config` redacts secrets by default; `-S/--show-secrets` opt-in.
- Token-leak hardening on every request path (`from None` chains, sanitized `HTTPError`).
- Downloads currently fail on some accounts due to a partial Qobuz signing rollout (MD5 → SHA-256 + HKDF). Login + metadata/search work; download subcommands exit cleanly with code 3 + README pointer rather than tracebacking.

## Testing

- 47 pytest tests covering auth, redaction, atomic writes, token-leak guards, dispatch precedence, corrupt-config recovery.
- Downloads verified end-to-end on a Studio account (FLAC 16/44.1) on 2026-04-26.